### PR TITLE
feat: Add multiple return values support

### DIFF
--- a/go/stdlib.go
+++ b/go/stdlib.go
@@ -172,7 +172,7 @@ func transpileFmtPrintf(out *strings.Builder, call *ast.CallExpr) {
 }
 
 func transpileFmtErrorf(out *strings.Builder, call *ast.CallExpr) {
-	out.WriteString("Some(Box::new(format!")
+	out.WriteString("std::sync::Arc::new(std::sync::Mutex::new(Some(Box::new(format!")
 	out.WriteString("(")
 
 	if len(call.Args) > 0 {
@@ -202,7 +202,7 @@ func transpileFmtErrorf(out *strings.Builder, call *ast.CallExpr) {
 		}
 	}
 
-	out.WriteString(")) as Box<dyn std::error::Error + Send + Sync>)")
+	out.WriteString(")) as Box<dyn std::error::Error + Send + Sync>)))")
 }
 
 func transpileStringsToUpper(out *strings.Builder, call *ast.CallExpr) {
@@ -237,7 +237,9 @@ func transpileStrconvAtoi(out *strings.Builder, call *ast.CallExpr) {
 	if len(call.Args) > 0 {
 		out.WriteString("match ")
 		TranspileExpression(out, call.Args[0])
-		out.WriteString(".parse::<i32>() { Ok(n) => (n, None), Err(e) => (0, Some(Box::new(e) as Box<dyn std::error::Error + Send + Sync>)) }")
+		out.WriteString(".parse::<i32>() { ")
+		out.WriteString("Ok(n) => (std::sync::Arc::new(std::sync::Mutex::new(Some(n))), std::sync::Arc::new(std::sync::Mutex::new(None))), ")
+		out.WriteString("Err(e) => (std::sync::Arc::new(std::sync::Mutex::new(Some(Box::new(e) as Box<dyn std::error::Error + Send + Sync>)))) }")
 	}
 }
 

--- a/go/types.go
+++ b/go/types.go
@@ -7,6 +7,11 @@ import (
 func GoTypeToRust(expr ast.Expr) string {
 	baseType := goTypeToRustBase(expr)
 
+	// Special case for error type - it's already Option
+	if ident, ok := expr.(*ast.Ident); ok && ident.Name == "error" {
+		return "std::sync::Arc<std::sync::Mutex<" + baseType + ">>"
+	}
+
 	// Wrap everything in Arc<Mutex<Option<>>>
 	// Don't double-wrap pointers - they're already wrapped
 	if _, isPointer := expr.(*ast.StarExpr); !isPointer {


### PR DESCRIPTION
Implements basic support for Go functions with multiple return values

- Function declarations now generate Rust tuple return types
- Return statements wrap multiple values in tuples  
- Special handling for error types to avoid double Option wrapping
- Named return values are initialized with appropriate defaults
- Updated strconv.Atoi to return proper tuple

Basic multiple returns work correctly. Complex error handling patterns still need refinement.

## Summary by Sourcery

Implement basic multiple-return-value support by wrapping outputs in thread-safe optional containers, initializing named returns, refining error handling, and updating stdlib transpilation accordingly

New Features:
- Add support for Go functions with multiple return values by emitting Rust tuple return types wrapped in Arc<Mutex<Option<>>>
- Initialize named return parameters with appropriately wrapped default values in function bodies
- Special-handle nil error returns to produce Arc<Mutex<None>> and avoid double Option wrapping

Enhancements:
- Update standard library transpilation (fmt.Errorf, strconv.Atoi) to return tuples with values and errors wrapped in Arc<Mutex<Option<>>>
- Treat Go error types as already Option-wrapped in GoTypeToRust to prevent nested wrapping
- Switch to TranspileExpressionContext for LValue contexts in assignments