### PR TITLE
feat: Fix constants to not be wrapped

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 go2rust
 go2rust.exe
 go/go
+
+tests/**/target

--- a/go/expr.go
+++ b/go/expr.go
@@ -37,7 +37,11 @@ func TranspileExpressionContext(out *strings.Builder, expr ast.Expr, ctx ExprCon
 		} else if e.Name[0] >= 'A' && e.Name[0] <= 'Z' && e.Name != "String" {
 			// Likely a constant - convert to UPPER_SNAKE_CASE
 			out.WriteString(strings.ToUpper(ToSnakeCase(e.Name)))
-		} else if e.Name == "true" || e.Name == "false" || rangeLoopVars[e.Name] {
+		} else if e.Name == "true" || e.Name == "false" {
+			out.WriteString(e.Name)
+		} else if _, isRangeVar := rangeLoopVars[e.Name]; isRangeVar {
+			out.WriteString(e.Name)
+		} else if _, isLocalConst := localConstants[e.Name]; isLocalConst {
 			out.WriteString(e.Name)
 		} else {
 			// All variables are wrapped in Arc<Mutex<Option<T>>>

--- a/go/transpile.go
+++ b/go/transpile.go
@@ -6,8 +6,9 @@ import (
 	"strings"
 )
 
-// rangeLoopVars tracks variables that are range loop iterators and shouldn't be unwrapped
-var rangeLoopVars = make(map[string]bool)
+// These maps track the names and types of special variables that shouldn't be unwrapped
+var rangeLoopVars = make(map[string]string)
+var localConstants = make(map[string]string)
 
 func Transpile(file *ast.File) string {
 	var output strings.Builder

--- a/tests/XFAIL/blank_identifier/main.rs
+++ b/tests/XFAIL/blank_identifier/main.rs
@@ -4,8 +4,8 @@ pub fn multiple_returns() -> (std::sync::Arc<std::sync::Mutex<Option<i32>>>, std
 }
 
 pub fn process_slice(slice: std::sync::Arc<std::sync::Mutex<Option<Vec<i32>>>>) -> (std::sync::Arc<std::sync::Mutex<Option<i32>>>, std::sync::Arc<std::sync::Mutex<Option<i32>>>) {
-    let mut sum: std::sync::Arc<std::sync::Mutex<Option<i32>>> = 0;
-    let mut count: std::sync::Arc<std::sync::Mutex<Option<i32>>> = 0;
+    let mut sum: std::sync::Arc<std::sync::Mutex<Option<i32>>> = std::sync::Arc::new(std::sync::Mutex::new(Some(0)));
+    let mut count: std::sync::Arc<std::sync::Mutex<Option<i32>>> = std::sync::Arc::new(std::sync::Mutex::new(Some(0)));
 
     { let new_val = 0; *sum.lock().unwrap() = Some(new_val); };
     { let new_val = (*slice.lock().unwrap().as_ref().unwrap()).len(); *count.lock().unwrap() = Some(new_val); };
@@ -17,11 +17,11 @@ pub fn process_slice(slice: std::sync::Arc<std::sync::Mutex<Option<Vec<i32>>>>) 
 
 fn main() {
     println!("{}", "=== Ignoring return values ===".to_string());
-    let (mut (*num.lock().unwrap().as_ref().unwrap()), (*_.lock().unwrap().as_ref().unwrap()), (*_.lock().unwrap().as_ref().unwrap())) = multiple_returns();
+    let (mut num, _, _) = multiple_returns();
     print!("Only using first return: {}\n", (*num.lock().unwrap().as_ref().unwrap()));
-    let ((*_.lock().unwrap().as_ref().unwrap()), mut (*str.lock().unwrap().as_ref().unwrap()), (*_.lock().unwrap().as_ref().unwrap())) = multiple_returns();
+    let (_, mut str, _) = multiple_returns();
     print!("Only using middle return: {}\n", (*str.lock().unwrap().as_ref().unwrap()));
-    let ((*_.lock().unwrap().as_ref().unwrap()), (*_.lock().unwrap().as_ref().unwrap()), mut (*flag.lock().unwrap().as_ref().unwrap())) = multiple_returns();
+    let (_, _, mut flag) = multiple_returns();
     print!("Only using last return: {}\n", (*flag.lock().unwrap().as_ref().unwrap()));
     println!("{}", "\n=== Ignoring in range loops ===".to_string());
     let mut slice = std::sync::Arc::new(std::sync::Mutex::new(Some(vec![10, 20, 30, 40, 50])));
@@ -53,9 +53,9 @@ fn main() {
     }
     println!();
     println!("{}", "\n=== Ignoring some return values in assignment ===".to_string());
-    let (mut (*sum.lock().unwrap().as_ref().unwrap()), (*_.lock().unwrap().as_ref().unwrap())) = process_slice(std::sync::Arc::new(std::sync::Mutex::new(Some((*slice.lock().unwrap().as_ref().unwrap())))));
+    let (mut sum, _) = process_slice(std::sync::Arc::new(std::sync::Mutex::new(Some((*slice.lock().unwrap().as_ref().unwrap())))));
     print!("Sum (ignoring count): {}\n", (*sum.lock().unwrap().as_ref().unwrap()));
-    let ((*_.lock().unwrap().as_ref().unwrap()), mut (*count.lock().unwrap().as_ref().unwrap())) = process_slice(std::sync::Arc::new(std::sync::Mutex::new(Some((*slice.lock().unwrap().as_ref().unwrap())))));
+    let (_, mut count) = process_slice(std::sync::Arc::new(std::sync::Mutex::new(Some((*slice.lock().unwrap().as_ref().unwrap())))));
     print!("Count (ignoring sum): {}\n", (*count.lock().unwrap().as_ref().unwrap()));
     println!("{}", "\n=== Blank identifier in declarations ===".to_string());
     let _ = "This string is assigned but not used".to_string();
@@ -63,11 +63,11 @@ fn main() {
     print!("a={}, c={} (middle value ignored)\n", (*a.lock().unwrap().as_ref().unwrap()), (*c.lock().unwrap().as_ref().unwrap()));
     println!("{}", "\n=== Blank identifier with type assertion ===".to_string());
     let mut value = std::sync::Arc::new(std::sync::Mutex::new(Some("hello world".to_string())));
-    let ((*_.lock().unwrap().as_ref().unwrap()), mut (*ok.lock().unwrap().as_ref().unwrap())) = match (*value.lock().unwrap().as_ref().unwrap()).downcast_ref::<String>() { Some(v) => (v.clone(), true), None => (String::new(), false) };
+    let (_, mut ok) = match (*value.lock().unwrap().as_ref().unwrap()).downcast_ref::<String>() { Some(v) => (v.clone(), true), None => (String::new(), false) };
     if (*ok.lock().unwrap().as_ref().unwrap()) {
         println!("{}", "Value is a string (but we ignored the actual value)".to_string());
     }
-    let ((*_.lock().unwrap().as_ref().unwrap()), mut (*ok.lock().unwrap().as_ref().unwrap())) = match (*value.lock().unwrap().as_ref().unwrap()).downcast_ref::<i32>() { Some(v) => (v.clone(), true), None => (0, false) };
+    let (_, mut ok) = match (*value.lock().unwrap().as_ref().unwrap()).downcast_ref::<i32>() { Some(v) => (v.clone(), true), None => (0, false) };
     if (*ok.lock().unwrap().as_ref().unwrap()) {
         println!("{}", "Value is an int".to_string());
     } else {
@@ -83,7 +83,7 @@ fn main() {
         println!("{}", "Received a value (but ignored it)".to_string());
     }
     println!("{}", "\n=== Blank identifier in error handling ===".to_string());
-    let (mut (*result.lock().unwrap().as_ref().unwrap()), (*_.lock().unwrap().as_ref().unwrap())) = process_slice(std::sync::Arc::new(std::sync::Mutex::new(Some(vec![1, 2, 3, 4, 5]))));
+    let (mut result, _) = process_slice(std::sync::Arc::new(std::sync::Mutex::new(Some(vec![1, 2, 3, 4, 5]))));
     print!("Result (ignoring potential error): {}\n", (*result.lock().unwrap().as_ref().unwrap()));
     println!("{}", "\n=== Complex example ===".to_string());
     let mut data = std::sync::Arc::new(std::sync::Mutex::new(Some(vec![, , ])));

--- a/tests/XFAIL/channels_basic/main.rs
+++ b/tests/XFAIL/channels_basic/main.rs
@@ -11,7 +11,7 @@ pub fn sender(ch: std::sync::Arc<std::sync::Mutex<Option<Unknown>>>) {
 
 pub fn receiver(ch: std::sync::Arc<std::sync::Mutex<Option<Unknown>>>) {
     while true {
-        let (mut (*value.lock().unwrap().as_ref().unwrap()), mut (*ok.lock().unwrap().as_ref().unwrap())) = <-(*ch.lock().unwrap().as_ref().unwrap());
+        let (mut value, mut ok) = <-(*ch.lock().unwrap().as_ref().unwrap());
         if !(*ok.lock().unwrap().as_ref().unwrap()) {
         println!("{}", "Channel closed".to_string());
         

--- a/tests/XFAIL/complex_expressions/main.rs
+++ b/tests/XFAIL/complex_expressions/main.rs
@@ -42,7 +42,7 @@ fn main() {
     print!("*ptr + (*ptr * 2) - (*ptr / 2) = {}\n", (*ptrResult.lock().unwrap().as_ref().unwrap()));
     println!("{}", "\n=== Type assertion expressions ===".to_string());
     let mut iface = std::sync::Arc::new(std::sync::Mutex::new(Some(100)));
-    let (mut (*intVal.lock().unwrap().as_ref().unwrap()), mut (*ok.lock().unwrap().as_ref().unwrap())) = match (*iface.lock().unwrap().as_ref().unwrap()).downcast_ref::<i32>() { Some(v) => (v.clone(), true), None => (0, false) };
+    let (mut intVal, mut ok) = match (*iface.lock().unwrap().as_ref().unwrap()).downcast_ref::<i32>() { Some(v) => (v.clone(), true), None => (0, false) };
     if (*ok.lock().unwrap().as_ref().unwrap()) {
         let mut assertResult = std::sync::Arc::new(std::sync::Mutex::new(Some((*intVal.lock().unwrap().as_ref().unwrap()) * 2 +  * 3)));
         print!("Type assertion result: {}\n", (*assertResult.lock().unwrap().as_ref().unwrap()));

--- a/tests/XFAIL/constants_basic/main.rs
+++ b/tests/XFAIL/constants_basic/main.rs
@@ -4,8 +4,8 @@ const MAX_USERS: i32 = 100;
 
 
 const NAME: &'static str = "Go2Rust";
-const VERSION: std::sync::Arc<std::sync::Mutex<Option<f64>>> = 1.0;
-const DEBUG: std::sync::Arc<std::sync::Mutex<Option<bool>>> = true;
+const VERSION: f64 = 1.0;
+const DEBUG: bool = true;
 
 
 const SUNDAY: i32 = 0;
@@ -67,31 +67,31 @@ fn main() {
     print!("EE = {}\n", E_E);
     print!("F = {}\n", F);
     println!("{}", "\n=== Local constants ===".to_string());
-    const LOCAL_CONST: i32 = 42;
+    const localConst: i32 = 42;
 
-    const X: i32 = 10;
-const Y: i32 = 20;
-const Z: i32 = X + Y;
+    const x: i32 = 10;
+const y: i32 = 20;
+const z: i32 = x + y;
 
-    print!("localConst = {}\n", (*localConst.lock().unwrap().as_ref().unwrap()));
-    print!("x = {}, y = {}, z = {}\n", (*x.lock().unwrap().as_ref().unwrap()), (*y.lock().unwrap().as_ref().unwrap()), (*z.lock().unwrap().as_ref().unwrap()));
+    print!("localConst = {}\n", localConst);
+    print!("x = {}, y = {}, z = {}\n", x, y, z);
     println!("{}", "\n=== Untyped constants in expressions ===".to_string());
-    const UNTYPED_INT: i32 = 100;
+    const untypedInt: i32 = 100;
 
-    const UNTYPED_FLOAT: f64 = 3.14;
+    const untypedFloat: f64 = 3.14;
 
-    let mut i = std::sync::Arc::new(std::sync::Mutex::new(Some((*untypedInt.lock().unwrap().as_ref().unwrap()))));
-    let mut f = std::sync::Arc::new(std::sync::Mutex::new(Some((*untypedFloat.lock().unwrap().as_ref().unwrap()))));
-    let mut mixed = std::sync::Arc::new(std::sync::Mutex::new(Some((*untypedInt.lock().unwrap().as_ref().unwrap()) + 3)));
+    let mut i = std::sync::Arc::new(std::sync::Mutex::new(Some(untypedInt)));
+    let mut f = std::sync::Arc::new(std::sync::Mutex::new(Some(untypedFloat)));
+    let mut mixed = std::sync::Arc::new(std::sync::Mutex::new(Some(untypedInt + 3)));
     print!("i = {}\n", (*i.lock().unwrap().as_ref().unwrap()));
     print!("f = {:.2}\n", (*f.lock().unwrap().as_ref().unwrap()));
     print!("mixed = {}\n", (*mixed.lock().unwrap().as_ref().unwrap()));
     println!("{}", "\n=== String constants ===".to_string());
-    const GREETING: &'static str = "Hello";
+    const greeting: &'static str = "Hello";
 
-    const TARGET: &'static str = "World";
+    const target: &'static str = "World";
 
-    const MESSAGE: i32 = GREETING + ", " + TARGET + "!";
+    const message: &'static str = greeting + ", " + target + "!";
 
-    println!("{}", (*message.lock().unwrap().as_ref().unwrap()));
+    println!("{}", message);
 }

--- a/tests/XFAIL/error_handling/main.rs
+++ b/tests/XFAIL/error_handling/main.rs
@@ -1,15 +1,15 @@
-pub fn divide(a: std::sync::Arc<std::sync::Mutex<Option<f64>>>, b: std::sync::Arc<std::sync::Mutex<Option<f64>>>) -> (std::sync::Arc<std::sync::Mutex<Option<f64>>>, std::sync::Arc<std::sync::Mutex<Option<Option<Box<dyn std::error::Error + Send + Sync>>>>>) {
+pub fn divide(a: std::sync::Arc<std::sync::Mutex<Option<f64>>>, b: std::sync::Arc<std::sync::Mutex<Option<f64>>>) -> (std::sync::Arc<std::sync::Mutex<Option<f64>>>, std::sync::Arc<std::sync::Mutex<Option<Box<dyn std::error::Error + Send + Sync>>>>) {
 
     if (*b.lock().unwrap().as_ref().unwrap()) == 0 {
         return (std::sync::Arc::new(std::sync::Mutex::new(Some(0))), std::sync::Arc::new(std::sync::Mutex::new(Some((*errors.lock().unwrap().as_ref().unwrap()).new(std::sync::Arc::new(std::sync::Mutex::new(Some("division by zero".to_string()))))))));
     }
-    return (std::sync::Arc::new(std::sync::Mutex::new(Some((*a.lock().unwrap().as_ref().unwrap()) / (*b.lock().unwrap().as_ref().unwrap())))), std::sync::Arc::new(std::sync::Mutex::new(Some(None))));
+    return (std::sync::Arc::new(std::sync::Mutex::new(Some((*a.lock().unwrap().as_ref().unwrap()) / (*b.lock().unwrap().as_ref().unwrap())))), std::sync::Arc::new(std::sync::Mutex::new(None)));
 }
 
-pub fn sqrt(x: std::sync::Arc<std::sync::Mutex<Option<f64>>>) -> (std::sync::Arc<std::sync::Mutex<Option<f64>>>, std::sync::Arc<std::sync::Mutex<Option<Option<Box<dyn std::error::Error + Send + Sync>>>>>) {
+pub fn sqrt(x: std::sync::Arc<std::sync::Mutex<Option<f64>>>) -> (std::sync::Arc<std::sync::Mutex<Option<f64>>>, std::sync::Arc<std::sync::Mutex<Option<Box<dyn std::error::Error + Send + Sync>>>>) {
 
     if (*x.lock().unwrap().as_ref().unwrap()) < 0 {
-        return (std::sync::Arc::new(std::sync::Mutex::new(Some(0))), std::sync::Arc::new(std::sync::Mutex::new(Some(Some(Box::new(format!("cannot take square root of negative number: {}", (*x.lock().unwrap().as_ref().unwrap()))) as Box<dyn std::error::Error + Send + Sync>)))));
+        return (std::sync::Arc::new(std::sync::Mutex::new(Some(0))), std::sync::Arc::new(std::sync::Mutex::new(Some(std::sync::Arc::new(std::sync::Mutex::new(Some(Box::new(format!("cannot take square root of negative number: {}", (*x.lock().unwrap().as_ref().unwrap()))) as Box<dyn std::error::Error + Send + Sync>)))))));
     }
     let mut result = std::sync::Arc::new(std::sync::Mutex::new(Some((*x.lock().unwrap().as_ref().unwrap()) / 2)));
     let mut i = std::sync::Arc::new(std::sync::Mutex::new(Some(0)));
@@ -17,7 +17,7 @@ pub fn sqrt(x: std::sync::Arc<std::sync::Mutex<Option<f64>>>) -> (std::sync::Arc
         { let new_val =  / 2; *result.lock().unwrap() = Some(new_val); };
         { let mut guard = i.lock().unwrap(); *guard = Some(guard.as_ref().unwrap() + 1); }
     }
-    return (std::sync::Arc::new(std::sync::Mutex::new(Some((*result.lock().unwrap().as_ref().unwrap()).clone()))), std::sync::Arc::new(std::sync::Mutex::new(Some(None))));
+    return (std::sync::Arc::new(std::sync::Mutex::new(Some((*result.lock().unwrap().as_ref().unwrap()).clone()))), std::sync::Arc::new(std::sync::Mutex::new(None)));
 }
 
 #[derive(Debug)]
@@ -31,7 +31,7 @@ pub fn error() -> std::sync::Arc<std::sync::Mutex<Option<String>>> {
     return std::sync::Arc::new(std::sync::Mutex::new(Some((*fmt.lock().unwrap().as_ref().unwrap()).sprintf(std::sync::Arc::new(std::sync::Mutex::new(Some("Error %d: %s".to_string()))), std::sync::Arc::new(std::sync::Mutex::new(Some((*e.lock().unwrap().as_ref().unwrap()).code))), std::sync::Arc::new(std::sync::Mutex::new(Some((*e.lock().unwrap().as_ref().unwrap()).message)))))));
 }
 
-pub fn process_value(val: std::sync::Arc<std::sync::Mutex<Option<i32>>>) -> std::sync::Arc<std::sync::Mutex<Option<Option<Box<dyn std::error::Error + Send + Sync>>>>> {
+pub fn process_value(val: std::sync::Arc<std::sync::Mutex<Option<i32>>>) -> std::sync::Arc<std::sync::Mutex<Option<Box<dyn std::error::Error + Send + Sync>>>> {
 
     if (*val.lock().unwrap().as_ref().unwrap()) < 0 {
         return std::sync::Arc::new(std::sync::Mutex::new(Some(CustomError { code: 100, message: "negative value not allowed".to_string() })));
@@ -39,23 +39,23 @@ pub fn process_value(val: std::sync::Arc<std::sync::Mutex<Option<i32>>>) -> std:
     if (*val.lock().unwrap().as_ref().unwrap()) > 100 {
         return std::sync::Arc::new(std::sync::Mutex::new(Some(CustomError { code: 200, message: "value too large".to_string() })));
     }
-    return std::sync::Arc::new(std::sync::Mutex::new(Some(None)));
+    return std::sync::Arc::new(std::sync::Mutex::new(None));
 }
 
 fn main() {
-    let (mut (*result.lock().unwrap().as_ref().unwrap()), mut (*err.lock().unwrap().as_ref().unwrap())) = divide(std::sync::Arc::new(std::sync::Mutex::new(Some(10))), std::sync::Arc::new(std::sync::Mutex::new(Some(2))));
+    let (mut result, mut err) = divide(std::sync::Arc::new(std::sync::Mutex::new(Some(10))), std::sync::Arc::new(std::sync::Mutex::new(Some(2))));
     if (*err.lock().unwrap().as_ref().unwrap()).is_some() {
         println!("{} {}", "Error:".to_string(), (*err.lock().unwrap().as_ref().unwrap()));
     } else {
         println!("{} {}", "10 / 2 =".to_string(), (*result.lock().unwrap().as_ref().unwrap()));
     }
-    ((*result.lock().unwrap().as_ref().unwrap()), (*err.lock().unwrap().as_ref().unwrap())) = divide(std::sync::Arc::new(std::sync::Mutex::new(Some(10))), std::sync::Arc::new(std::sync::Mutex::new(Some(0))));
+    (result, err) = divide(std::sync::Arc::new(std::sync::Mutex::new(Some(10))), std::sync::Arc::new(std::sync::Mutex::new(Some(0))));
     if (*err.lock().unwrap().as_ref().unwrap()).is_some() {
         println!("{} {}", "Error:".to_string(), (*err.lock().unwrap().as_ref().unwrap()));
     } else {
         println!("{} {}", "Result:".to_string(), (*result.lock().unwrap().as_ref().unwrap()));
     }
-    let (mut (*sqrtResult.lock().unwrap().as_ref().unwrap()), mut (*err.lock().unwrap().as_ref().unwrap())) = sqrt(std::sync::Arc::new(std::sync::Mutex::new(Some(-4))));
+    let (mut sqrtResult, mut err) = sqrt(std::sync::Arc::new(std::sync::Mutex::new(Some(-4))));
     if (*err.lock().unwrap().as_ref().unwrap()).is_some() {
         println!("{} {}", "Sqrt error:".to_string(), (*err.lock().unwrap().as_ref().unwrap()));
     } else {

--- a/tests/XFAIL/file_operations/main.rs
+++ b/tests/XFAIL/file_operations/main.rs
@@ -2,14 +2,14 @@ fn main() {
     println!("{}", "=== File Operations Test ===".to_string());
     let mut filename = std::sync::Arc::new(std::sync::Mutex::new(Some("test_file.txt".to_string())));
     println!("{}", "\n--- Writing to file ---".to_string());
-    let (mut (*file.lock().unwrap().as_ref().unwrap()), mut (*err.lock().unwrap().as_ref().unwrap())) = (*os.lock().unwrap().as_ref().unwrap()).create(std::sync::Arc::new(std::sync::Mutex::new(Some((*filename.lock().unwrap().as_ref().unwrap())))));
+    let (mut file, mut err) = (*os.lock().unwrap().as_ref().unwrap()).create(std::sync::Arc::new(std::sync::Mutex::new(Some((*filename.lock().unwrap().as_ref().unwrap())))));
     if (*err.lock().unwrap().as_ref().unwrap()).is_some() {
         print!("Error creating file: {}\n", (*err.lock().unwrap().as_ref().unwrap()));
         return;
     }
     let mut content = std::sync::Arc::new(std::sync::Mutex::new(Some(vec!["Hello, World!".to_string(), "This is line 2".to_string(), "Go file operations".to_string(), "Line 4 with numbers: 123".to_string(), "Final line".to_string()])));
     for (i, line) in (*content.lock().unwrap().as_ref().unwrap()).iter().enumerate() {
-        let ((*_.lock().unwrap().as_ref().unwrap()), mut (*err.lock().unwrap().as_ref().unwrap())) = (*file.lock().unwrap().as_ref().unwrap()).write_string(std::sync::Arc::new(std::sync::Mutex::new(Some(line + "\n".to_string()))));
+        let (_, mut err) = (*file.lock().unwrap().as_ref().unwrap()).write_string(std::sync::Arc::new(std::sync::Mutex::new(Some(line + "\n".to_string()))));
         if (*err.lock().unwrap().as_ref().unwrap()).is_some() {
         print!("Error writing line {}: {}\n", i + 1, (*err.lock().unwrap().as_ref().unwrap()));
         (*file.lock().unwrap().as_ref().unwrap()).close();
@@ -20,14 +20,14 @@ fn main() {
     (*file.lock().unwrap().as_ref().unwrap()).close();
     print!("File '{}' created successfully\n", (*filename.lock().unwrap().as_ref().unwrap()));
     println!("{}", "\n--- Reading entire file ---".to_string());
-    let (mut (*data.lock().unwrap().as_ref().unwrap()), mut (*err.lock().unwrap().as_ref().unwrap())) = (*os.lock().unwrap().as_ref().unwrap()).read_file(std::sync::Arc::new(std::sync::Mutex::new(Some((*filename.lock().unwrap().as_ref().unwrap())))));
+    let (mut data, mut err) = (*os.lock().unwrap().as_ref().unwrap()).read_file(std::sync::Arc::new(std::sync::Mutex::new(Some((*filename.lock().unwrap().as_ref().unwrap())))));
     if (*err.lock().unwrap().as_ref().unwrap()).is_some() {
         print!("Error reading file: {}\n", (*err.lock().unwrap().as_ref().unwrap()));
         return;
     }
     print!("File contents:\n{}", string(std::sync::Arc::new(std::sync::Mutex::new(Some((*data.lock().unwrap().as_ref().unwrap()))))));
     println!("{}", "\n--- Reading file line by line ---".to_string());
-    ((*file.lock().unwrap().as_ref().unwrap()), (*err.lock().unwrap().as_ref().unwrap())) = (*os.lock().unwrap().as_ref().unwrap()).open(std::sync::Arc::new(std::sync::Mutex::new(Some((*filename.lock().unwrap().as_ref().unwrap())))));
+    (file, err) = (*os.lock().unwrap().as_ref().unwrap()).open(std::sync::Arc::new(std::sync::Mutex::new(Some((*filename.lock().unwrap().as_ref().unwrap())))));
     if (*err.lock().unwrap().as_ref().unwrap()).is_some() {
         print!("Error opening file: {}\n", (*err.lock().unwrap().as_ref().unwrap()));
         return;
@@ -46,14 +46,14 @@ fn main() {
         return;
     }
     println!("{}", "\n--- Appending to file ---".to_string());
-    ((*file.lock().unwrap().as_ref().unwrap()), (*err.lock().unwrap().as_ref().unwrap())) = (*os.lock().unwrap().as_ref().unwrap()).open_file(std::sync::Arc::new(std::sync::Mutex::new(Some((*filename.lock().unwrap().as_ref().unwrap())))), std::sync::Arc::new(std::sync::Mutex::new(Some((*os.lock().unwrap().as_ref().unwrap()).o__a_p_p_e_n_d | (*os.lock().unwrap().as_ref().unwrap()).o__w_r_o_n_l_y))), std::sync::Arc::new(std::sync::Mutex::new(Some(0644))));
+    (file, err) = (*os.lock().unwrap().as_ref().unwrap()).open_file(std::sync::Arc::new(std::sync::Mutex::new(Some((*filename.lock().unwrap().as_ref().unwrap())))), std::sync::Arc::new(std::sync::Mutex::new(Some((*os.lock().unwrap().as_ref().unwrap()).o__a_p_p_e_n_d | (*os.lock().unwrap().as_ref().unwrap()).o__w_r_o_n_l_y))), std::sync::Arc::new(std::sync::Mutex::new(Some(0644))));
     if (*err.lock().unwrap().as_ref().unwrap()).is_some() {
         print!("Error opening file for append: {}\n", (*err.lock().unwrap().as_ref().unwrap()));
         return;
     }
     let mut appendContent = std::sync::Arc::new(std::sync::Mutex::new(Some(vec!["Appended line 1".to_string(), "Appended line 2".to_string()])));
     for (_, line) in (*appendContent.lock().unwrap().as_ref().unwrap()).iter().enumerate() {
-        let (_, mut (*err.lock().unwrap().as_ref().unwrap())) = (*file.lock().unwrap().as_ref().unwrap()).write_string(std::sync::Arc::new(std::sync::Mutex::new(Some(line + "\n".to_string()))));
+        let (_, mut err) = (*file.lock().unwrap().as_ref().unwrap()).write_string(std::sync::Arc::new(std::sync::Mutex::new(Some(line + "\n".to_string()))));
         if (*err.lock().unwrap().as_ref().unwrap()).is_some() {
         print!("Error appending: {}\n", (*err.lock().unwrap().as_ref().unwrap()));
         (*file.lock().unwrap().as_ref().unwrap()).close();
@@ -63,14 +63,14 @@ fn main() {
     }
     (*file.lock().unwrap().as_ref().unwrap()).close();
     println!("{}", "\n--- Reading updated file ---".to_string());
-    ((*data.lock().unwrap().as_ref().unwrap()), (*err.lock().unwrap().as_ref().unwrap())) = (*os.lock().unwrap().as_ref().unwrap()).read_file(std::sync::Arc::new(std::sync::Mutex::new(Some((*filename.lock().unwrap().as_ref().unwrap())))));
+    (data, err) = (*os.lock().unwrap().as_ref().unwrap()).read_file(std::sync::Arc::new(std::sync::Mutex::new(Some((*filename.lock().unwrap().as_ref().unwrap())))));
     if (*err.lock().unwrap().as_ref().unwrap()).is_some() {
         print!("Error reading updated file: {}\n", (*err.lock().unwrap().as_ref().unwrap()));
         return;
     }
     print!("Updated file contents:\n{}", string(std::sync::Arc::new(std::sync::Mutex::new(Some((*data.lock().unwrap().as_ref().unwrap()))))));
     println!("{}", "\n--- File information ---".to_string());
-    let (mut (*fileInfo.lock().unwrap().as_ref().unwrap()), mut (*err.lock().unwrap().as_ref().unwrap())) = (*os.lock().unwrap().as_ref().unwrap()).stat(std::sync::Arc::new(std::sync::Mutex::new(Some((*filename.lock().unwrap().as_ref().unwrap())))));
+    let (mut fileInfo, mut err) = (*os.lock().unwrap().as_ref().unwrap()).stat(std::sync::Arc::new(std::sync::Mutex::new(Some((*filename.lock().unwrap().as_ref().unwrap())))));
     if (*err.lock().unwrap().as_ref().unwrap()).is_some() {
         print!("Error getting file info: {}\n", (*err.lock().unwrap().as_ref().unwrap()));
         return;
@@ -82,26 +82,26 @@ fn main() {
     print!("Is directory: {}\n", (*fileInfo.lock().unwrap().as_ref().unwrap()).is_dir());
     println!("{}", "\n--- Copying file ---".to_string());
     let mut copyFilename = std::sync::Arc::new(std::sync::Mutex::new(Some("test_file_copy.txt".to_string())));
-    let (mut (*sourceFile.lock().unwrap().as_ref().unwrap()), mut (*err.lock().unwrap().as_ref().unwrap())) = (*os.lock().unwrap().as_ref().unwrap()).open(std::sync::Arc::new(std::sync::Mutex::new(Some((*filename.lock().unwrap().as_ref().unwrap())))));
+    let (mut sourceFile, mut err) = (*os.lock().unwrap().as_ref().unwrap()).open(std::sync::Arc::new(std::sync::Mutex::new(Some((*filename.lock().unwrap().as_ref().unwrap())))));
     if (*err.lock().unwrap().as_ref().unwrap()).is_some() {
         print!("Error opening source file: {}\n", (*err.lock().unwrap().as_ref().unwrap()));
         return;
     }
     
-    let (mut (*destFile.lock().unwrap().as_ref().unwrap()), mut (*err.lock().unwrap().as_ref().unwrap())) = (*os.lock().unwrap().as_ref().unwrap()).create(std::sync::Arc::new(std::sync::Mutex::new(Some((*copyFilename.lock().unwrap().as_ref().unwrap())))));
+    let (mut destFile, mut err) = (*os.lock().unwrap().as_ref().unwrap()).create(std::sync::Arc::new(std::sync::Mutex::new(Some((*copyFilename.lock().unwrap().as_ref().unwrap())))));
     if (*err.lock().unwrap().as_ref().unwrap()).is_some() {
         print!("Error creating destination file: {}\n", (*err.lock().unwrap().as_ref().unwrap()));
         return;
     }
     
-    let (mut (*bytesWritten.lock().unwrap().as_ref().unwrap()), mut (*err.lock().unwrap().as_ref().unwrap())) = (*io.lock().unwrap().as_ref().unwrap()).copy(std::sync::Arc::new(std::sync::Mutex::new(Some((*destFile.lock().unwrap().as_ref().unwrap())))), std::sync::Arc::new(std::sync::Mutex::new(Some((*sourceFile.lock().unwrap().as_ref().unwrap())))));
+    let (mut bytesWritten, mut err) = (*io.lock().unwrap().as_ref().unwrap()).copy(std::sync::Arc::new(std::sync::Mutex::new(Some((*destFile.lock().unwrap().as_ref().unwrap())))), std::sync::Arc::new(std::sync::Mutex::new(Some((*sourceFile.lock().unwrap().as_ref().unwrap())))));
     if (*err.lock().unwrap().as_ref().unwrap()).is_some() {
         print!("Error copying file: {}\n", (*err.lock().unwrap().as_ref().unwrap()));
         return;
     }
     print!("Copied {} bytes to '{}'\n", (*bytesWritten.lock().unwrap().as_ref().unwrap()), (*copyFilename.lock().unwrap().as_ref().unwrap()));
     println!("{}", "\n--- Processing file content ---".to_string());
-    ((*file.lock().unwrap().as_ref().unwrap()), (*err.lock().unwrap().as_ref().unwrap())) = (*os.lock().unwrap().as_ref().unwrap()).open(std::sync::Arc::new(std::sync::Mutex::new(Some((*filename.lock().unwrap().as_ref().unwrap())))));
+    (file, err) = (*os.lock().unwrap().as_ref().unwrap()).open(std::sync::Arc::new(std::sync::Mutex::new(Some((*filename.lock().unwrap().as_ref().unwrap())))));
     if (*err.lock().unwrap().as_ref().unwrap()).is_some() {
         print!("Error opening file: {}\n", (*err.lock().unwrap().as_ref().unwrap()));
         return;
@@ -127,7 +127,7 @@ fn main() {
     print!("  Characters: {}\n", (*charCount.lock().unwrap().as_ref().unwrap()));
     println!("{}", "\n--- Writing formatted data ---".to_string());
     let mut dataFile = std::sync::Arc::new(std::sync::Mutex::new(Some("data.txt".to_string())));
-    ((*file.lock().unwrap().as_ref().unwrap()), (*err.lock().unwrap().as_ref().unwrap())) = (*os.lock().unwrap().as_ref().unwrap()).create(std::sync::Arc::new(std::sync::Mutex::new(Some((*dataFile.lock().unwrap().as_ref().unwrap())))));
+    (file, err) = (*os.lock().unwrap().as_ref().unwrap()).create(std::sync::Arc::new(std::sync::Mutex::new(Some((*dataFile.lock().unwrap().as_ref().unwrap())))));
     if (*err.lock().unwrap().as_ref().unwrap()).is_some() {
         print!("Error creating data file: {}\n", (*err.lock().unwrap().as_ref().unwrap()));
         return;
@@ -139,7 +139,7 @@ fn main() {
     (*fmt.lock().unwrap().as_ref().unwrap()).fprintf(std::sync::Arc::new(std::sync::Mutex::new(Some((*file.lock().unwrap().as_ref().unwrap())))), std::sync::Arc::new(std::sync::Mutex::new(Some("Active: %t\n".to_string()))), std::sync::Arc::new(std::sync::Mutex::new(Some(true))));
     print!("Formatted data written to '{}'\n", (*dataFile.lock().unwrap().as_ref().unwrap()));
     println!("{}", "\n--- Reading formatted data ---".to_string());
-    ((*data.lock().unwrap().as_ref().unwrap()), (*err.lock().unwrap().as_ref().unwrap())) = (*os.lock().unwrap().as_ref().unwrap()).read_file(std::sync::Arc::new(std::sync::Mutex::new(Some((*dataFile.lock().unwrap().as_ref().unwrap())))));
+    (data, err) = (*os.lock().unwrap().as_ref().unwrap()).read_file(std::sync::Arc::new(std::sync::Mutex::new(Some((*dataFile.lock().unwrap().as_ref().unwrap())))));
     if (*err.lock().unwrap().as_ref().unwrap()).is_some() {
         print!("Error reading data file: {}\n", (*err.lock().unwrap().as_ref().unwrap()));
         return;
@@ -148,7 +148,7 @@ fn main() {
     println!("{}", "\n--- Checking file existence ---".to_string());
     let mut files = std::sync::Arc::new(std::sync::Mutex::new(Some(vec![(*filename.lock().unwrap().as_ref().unwrap()), (*copyFilename.lock().unwrap().as_ref().unwrap()), (*dataFile.lock().unwrap().as_ref().unwrap()), "nonexistent.txt".to_string()])));
     for (_, f) in (*files.lock().unwrap().as_ref().unwrap()).iter().enumerate() {
-        let (_, mut (*err.lock().unwrap().as_ref().unwrap())) = (*os.lock().unwrap().as_ref().unwrap()).stat(std::sync::Arc::new(std::sync::Mutex::new(Some(f))));
+        let (_, mut err) = (*os.lock().unwrap().as_ref().unwrap()).stat(std::sync::Arc::new(std::sync::Mutex::new(Some(f))));
     if (*err.lock().unwrap().as_ref().unwrap()).is_none() {
         print!("File '{}' exists\n", f);
     } else if (*os.lock().unwrap().as_ref().unwrap()).is_not_exist(std::sync::Arc::new(std::sync::Mutex::new(Some((*err.lock().unwrap().as_ref().unwrap()))))) {
@@ -169,7 +169,7 @@ fn main() {
     }
     println!("{}", "\n--- Verifying cleanup ---".to_string());
     for (_, f) in (*filesToRemove.lock().unwrap().as_ref().unwrap()).iter().enumerate() {
-        let (_, mut (*err.lock().unwrap().as_ref().unwrap())) = (*os.lock().unwrap().as_ref().unwrap()).stat(std::sync::Arc::new(std::sync::Mutex::new(Some(f))));
+        let (_, mut err) = (*os.lock().unwrap().as_ref().unwrap()).stat(std::sync::Arc::new(std::sync::Mutex::new(Some(f))));
     if (*os.lock().unwrap().as_ref().unwrap()).is_not_exist(std::sync::Arc::new(std::sync::Mutex::new(Some((*err.lock().unwrap().as_ref().unwrap()))))) {
         print!("File '{}' successfully removed\n", f);
     } else {

--- a/tests/XFAIL/maps_basic/main.rs
+++ b/tests/XFAIL/maps_basic/main.rs
@@ -6,7 +6,7 @@ fn main() {
     println!("{} {:?}", "Ages map:".to_string(), (*ages.lock().unwrap().as_ref().unwrap()));
     let mut colors = std::sync::Arc::new(std::sync::Mutex::new(Some(std::collections::HashMap::<std::sync::Arc<std::sync::Mutex<Option<String>>>, std::sync::Arc<std::sync::Mutex<Option<String>>>>::from([("red".to_string(), "#FF0000".to_string()), ("green".to_string(), "#00FF00".to_string()), ("blue".to_string(), "#0000FF".to_string())]))));
     println!("{} {:?}", "Colors map:".to_string(), (*colors.lock().unwrap().as_ref().unwrap()));
-    let (mut (*age.lock().unwrap().as_ref().unwrap()), mut (*exists.lock().unwrap().as_ref().unwrap())) = ((*ages.lock().unwrap().as_ref().unwrap()).get(&"Alice".to_string()).cloned().unwrap_or_default(), (*ages.lock().unwrap().as_ref().unwrap()).contains_key(&"Alice".to_string()));
+    let (mut age, mut exists) = ((*ages.lock().unwrap().as_ref().unwrap()).get(&"Alice".to_string()).cloned().unwrap_or_default(), (*ages.lock().unwrap().as_ref().unwrap()).contains_key(&"Alice".to_string()));
     if (*exists.lock().unwrap().as_ref().unwrap()) {
         println!("{} {}", "Alice's age:".to_string(), (*age.lock().unwrap().as_ref().unwrap()));
     }

--- a/tests/XFAIL/multiple_returns/main.rs
+++ b/tests/XFAIL/multiple_returns/main.rs
@@ -3,13 +3,13 @@ pub fn divmod(a: std::sync::Arc<std::sync::Mutex<Option<i32>>>, b: std::sync::Ar
     return (std::sync::Arc::new(std::sync::Mutex::new(Some((*a.lock().unwrap().as_ref().unwrap()) / (*b.lock().unwrap().as_ref().unwrap())))), std::sync::Arc::new(std::sync::Mutex::new(Some((*a.lock().unwrap().as_ref().unwrap()) % (*b.lock().unwrap().as_ref().unwrap())))));
 }
 
-pub fn parse_number(s: std::sync::Arc<std::sync::Mutex<Option<String>>>) -> (std::sync::Arc<std::sync::Mutex<Option<i32>>>, std::sync::Arc<std::sync::Mutex<Option<Option<Box<dyn std::error::Error + Send + Sync>>>>>) {
+pub fn parse_number(s: std::sync::Arc<std::sync::Mutex<Option<String>>>) -> (std::sync::Arc<std::sync::Mutex<Option<i32>>>, std::sync::Arc<std::sync::Mutex<Option<Box<dyn std::error::Error + Send + Sync>>>>) {
 
-    let (mut (*num.lock().unwrap().as_ref().unwrap()), mut (*err.lock().unwrap().as_ref().unwrap())) = match (*s.lock().unwrap().as_ref().unwrap()).parse::<i32>() { Ok(n) => (n, None), Err(e) => (0, Some(Box::new(e) as Box<dyn std::error::Error + Send + Sync>)) };
+    let (mut num, mut err) = match (*s.lock().unwrap().as_ref().unwrap()).parse::<i32>() { Ok(n) => (std::sync::Arc::new(std::sync::Mutex::new(Some(n))), std::sync::Arc::new(std::sync::Mutex::new(None))), Err(e) => (std::sync::Arc::new(std::sync::Mutex::new(Some(Box::new(e) as Box<dyn std::error::Error + Send + Sync>)))) };
     if (*err.lock().unwrap().as_ref().unwrap()).is_some() {
-        return (std::sync::Arc::new(std::sync::Mutex::new(Some(0))), std::sync::Arc::new(std::sync::Mutex::new(Some(Some(Box::new(format!("failed to parse '{}': {}", (*s.lock().unwrap().as_ref().unwrap()), (*err.lock().unwrap().as_ref().unwrap()))) as Box<dyn std::error::Error + Send + Sync>)))));
+        return (std::sync::Arc::new(std::sync::Mutex::new(Some(0))), std::sync::Arc::new(std::sync::Mutex::new(Some(std::sync::Arc::new(std::sync::Mutex::new(Some(Box::new(format!("failed to parse '{}': {}", (*s.lock().unwrap().as_ref().unwrap()), (*err.lock().unwrap().as_ref().unwrap()))) as Box<dyn std::error::Error + Send + Sync>)))))));
     }
-    return (std::sync::Arc::new(std::sync::Mutex::new(Some((*num.lock().unwrap().as_ref().unwrap()).clone()))), std::sync::Arc::new(std::sync::Mutex::new(Some(None))));
+    return (std::sync::Arc::new(std::sync::Mutex::new(Some((*num.lock().unwrap().as_ref().unwrap()).clone()))), std::sync::Arc::new(std::sync::Mutex::new(None)));
 }
 
 pub fn get_name_age() -> (std::sync::Arc<std::sync::Mutex<Option<String>>>, std::sync::Arc<std::sync::Mutex<Option<i32>>>) {
@@ -18,8 +18,8 @@ pub fn get_name_age() -> (std::sync::Arc<std::sync::Mutex<Option<String>>>, std:
 }
 
 pub fn calculate(a: std::sync::Arc<std::sync::Mutex<Option<i32>>>, b: std::sync::Arc<std::sync::Mutex<Option<i32>>>) -> (std::sync::Arc<std::sync::Mutex<Option<i32>>>, std::sync::Arc<std::sync::Mutex<Option<i32>>>) {
-    let mut sum: std::sync::Arc<std::sync::Mutex<Option<i32>>> = 0;
-    let mut product: std::sync::Arc<std::sync::Mutex<Option<i32>>> = 0;
+    let mut sum: std::sync::Arc<std::sync::Mutex<Option<i32>>> = std::sync::Arc::new(std::sync::Mutex::new(Some(0)));
+    let mut product: std::sync::Arc<std::sync::Mutex<Option<i32>>> = std::sync::Arc::new(std::sync::Mutex::new(Some(0)));
 
     { let new_val = (*a.lock().unwrap().as_ref().unwrap()) + (*b.lock().unwrap().as_ref().unwrap()); *sum.lock().unwrap() = Some(new_val); };
     { let new_val = (*a.lock().unwrap().as_ref().unwrap()) * (*b.lock().unwrap().as_ref().unwrap()); *product.lock().unwrap() = Some(new_val); };
@@ -27,9 +27,9 @@ pub fn calculate(a: std::sync::Arc<std::sync::Mutex<Option<i32>>>, b: std::sync:
 }
 
 pub fn process_data(data: std::sync::Arc<std::sync::Mutex<Option<Vec<i32>>>>) -> (std::sync::Arc<std::sync::Mutex<Option<i32>>>, std::sync::Arc<std::sync::Mutex<Option<i32>>>, std::sync::Arc<std::sync::Mutex<Option<i32>>>) {
-    let mut min: std::sync::Arc<std::sync::Mutex<Option<i32>>> = 0;
-    let mut max: std::sync::Arc<std::sync::Mutex<Option<i32>>> = 0;
-    let mut sum: std::sync::Arc<std::sync::Mutex<Option<i32>>> = 0;
+    let mut min: std::sync::Arc<std::sync::Mutex<Option<i32>>> = std::sync::Arc::new(std::sync::Mutex::new(Some(0)));
+    let mut max: std::sync::Arc<std::sync::Mutex<Option<i32>>> = std::sync::Arc::new(std::sync::Mutex::new(Some(0)));
+    let mut sum: std::sync::Arc<std::sync::Mutex<Option<i32>>> = std::sync::Arc::new(std::sync::Mutex::new(Some(0)));
 
     if (*data.lock().unwrap().as_ref().unwrap()).len() == 0 {
         return (std::sync::Arc::new(std::sync::Mutex::new(Some(0))), std::sync::Arc::new(std::sync::Mutex::new(Some(0))), std::sync::Arc::new(std::sync::Mutex::new(Some(0))));
@@ -55,17 +55,17 @@ pub fn swap(a: std::sync::Arc<std::sync::Mutex<Option<String>>>, b: std::sync::A
 }
 
 pub fn get_person_info() -> (std::sync::Arc<std::sync::Mutex<Option<String>>>, std::sync::Arc<std::sync::Mutex<Option<i32>>>, std::sync::Arc<std::sync::Mutex<Option<f64>>>, std::sync::Arc<std::sync::Mutex<Option<bool>>>) {
-    let mut name: std::sync::Arc<std::sync::Mutex<Option<String>>> = String::new();
-    let mut age: std::sync::Arc<std::sync::Mutex<Option<i32>>> = 0;
-    let mut height: std::sync::Arc<std::sync::Mutex<Option<f64>>> = 0.0;
-    let mut married: std::sync::Arc<std::sync::Mutex<Option<bool>>> = false;
+    let mut name: std::sync::Arc<std::sync::Mutex<Option<String>>> = std::sync::Arc::new(std::sync::Mutex::new(Some(String::new())));
+    let mut age: std::sync::Arc<std::sync::Mutex<Option<i32>>> = std::sync::Arc::new(std::sync::Mutex::new(Some(0)));
+    let mut height: std::sync::Arc<std::sync::Mutex<Option<f64>>> = std::sync::Arc::new(std::sync::Mutex::new(Some(0.0)));
+    let mut married: std::sync::Arc<std::sync::Mutex<Option<bool>>> = std::sync::Arc::new(std::sync::Mutex::new(Some(false)));
 
     return (std::sync::Arc::new(std::sync::Mutex::new(Some("Bob".to_string()))), std::sync::Arc::new(std::sync::Mutex::new(Some(25))), std::sync::Arc::new(std::sync::Mutex::new(Some(5.9))), std::sync::Arc::new(std::sync::Mutex::new(Some(false))));
 }
 
 pub fn find_in_slice(slice: std::sync::Arc<std::sync::Mutex<Option<Vec<i32>>>>, target: std::sync::Arc<std::sync::Mutex<Option<i32>>>) -> (std::sync::Arc<std::sync::Mutex<Option<i32>>>, std::sync::Arc<std::sync::Mutex<Option<bool>>>) {
-    let mut index: std::sync::Arc<std::sync::Mutex<Option<i32>>> = 0;
-    let mut found: std::sync::Arc<std::sync::Mutex<Option<bool>>> = false;
+    let mut index: std::sync::Arc<std::sync::Mutex<Option<i32>>> = std::sync::Arc::new(std::sync::Mutex::new(Some(0)));
+    let mut found: std::sync::Arc<std::sync::Mutex<Option<bool>>> = std::sync::Arc::new(std::sync::Mutex::new(Some(false)));
 
     for (i, val) in (*slice.lock().unwrap().as_ref().unwrap()).iter().enumerate() {
         if val == (*target.lock().unwrap().as_ref().unwrap()) {
@@ -75,81 +75,81 @@ pub fn find_in_slice(slice: std::sync::Arc<std::sync::Mutex<Option<Vec<i32>>>>, 
     return (std::sync::Arc::new(std::sync::Mutex::new(Some(-1))), std::sync::Arc::new(std::sync::Mutex::new(Some(false))));
 }
 
-pub fn safe_divide(a: std::sync::Arc<std::sync::Mutex<Option<f64>>>, b: std::sync::Arc<std::sync::Mutex<Option<f64>>>) -> (std::sync::Arc<std::sync::Mutex<Option<f64>>>, std::sync::Arc<std::sync::Mutex<Option<Option<Box<dyn std::error::Error + Send + Sync>>>>>) {
-    let mut result: std::sync::Arc<std::sync::Mutex<Option<f64>>> = 0.0;
-    let mut err: std::sync::Arc<std::sync::Mutex<Option<Option<Box<dyn std::error::Error + Send + Sync>>>>> = None;
+pub fn safe_divide(a: std::sync::Arc<std::sync::Mutex<Option<f64>>>, b: std::sync::Arc<std::sync::Mutex<Option<f64>>>) -> (std::sync::Arc<std::sync::Mutex<Option<f64>>>, std::sync::Arc<std::sync::Mutex<Option<Box<dyn std::error::Error + Send + Sync>>>>) {
+    let mut result: std::sync::Arc<std::sync::Mutex<Option<f64>>> = std::sync::Arc::new(std::sync::Mutex::new(Some(0.0)));
+    let mut err: std::sync::Arc<std::sync::Mutex<Option<Box<dyn std::error::Error + Send + Sync>>>> = std::sync::Arc::new(std::sync::Mutex::new(None));
 
     if (*b.lock().unwrap().as_ref().unwrap()) == 0 {
-        return (std::sync::Arc::new(std::sync::Mutex::new(Some(0))), std::sync::Arc::new(std::sync::Mutex::new(Some(Some(Box::new(format!("division by zero")) as Box<dyn std::error::Error + Send + Sync>)))));
+        return (std::sync::Arc::new(std::sync::Mutex::new(Some(0))), std::sync::Arc::new(std::sync::Mutex::new(Some(std::sync::Arc::new(std::sync::Mutex::new(Some(Box::new(format!("division by zero")) as Box<dyn std::error::Error + Send + Sync>)))))));
     }
-    return (std::sync::Arc::new(std::sync::Mutex::new(Some((*a.lock().unwrap().as_ref().unwrap()) / (*b.lock().unwrap().as_ref().unwrap())))), std::sync::Arc::new(std::sync::Mutex::new(Some(None))));
+    return (std::sync::Arc::new(std::sync::Mutex::new(Some((*a.lock().unwrap().as_ref().unwrap()) / (*b.lock().unwrap().as_ref().unwrap())))), std::sync::Arc::new(std::sync::Mutex::new(None)));
 }
 
 fn main() {
     println!("{}", "=== Basic multiple returns ===".to_string());
-    let (mut (*quotient.lock().unwrap().as_ref().unwrap()), mut (*remainder.lock().unwrap().as_ref().unwrap())) = divmod(std::sync::Arc::new(std::sync::Mutex::new(Some(17))), std::sync::Arc::new(std::sync::Mutex::new(Some(5))));
+    let (mut quotient, mut remainder) = divmod(std::sync::Arc::new(std::sync::Mutex::new(Some(17))), std::sync::Arc::new(std::sync::Mutex::new(Some(5))));
     print!("17 / 5 = {} remainder {}\n", (*quotient.lock().unwrap().as_ref().unwrap()), (*remainder.lock().unwrap().as_ref().unwrap()));
-    let (mut (*name.lock().unwrap().as_ref().unwrap()), mut (*age.lock().unwrap().as_ref().unwrap())) = get_name_age();
+    let (mut name, mut age) = get_name_age();
     print!("Name: {}, Age: {}\n", (*name.lock().unwrap().as_ref().unwrap()), (*age.lock().unwrap().as_ref().unwrap()));
     println!("{}", "\n=== Multiple returns with errors ===".to_string());
-    let (mut (*num.lock().unwrap().as_ref().unwrap()), mut (*err.lock().unwrap().as_ref().unwrap())) = parse_number(std::sync::Arc::new(std::sync::Mutex::new(Some("123".to_string()))));
+    let (mut num, mut err) = parse_number(std::sync::Arc::new(std::sync::Mutex::new(Some("123".to_string()))));
     if (*err.lock().unwrap().as_ref().unwrap()).is_some() {
         print!("Error: {}\n", (*err.lock().unwrap().as_ref().unwrap()));
     } else {
         print!("Parsed number: {}\n", (*num.lock().unwrap().as_ref().unwrap()));
     }
-    ((*num.lock().unwrap().as_ref().unwrap()), (*err.lock().unwrap().as_ref().unwrap())) = parse_number(std::sync::Arc::new(std::sync::Mutex::new(Some("abc".to_string()))));
+    (num, err) = parse_number(std::sync::Arc::new(std::sync::Mutex::new(Some("abc".to_string()))));
     if (*err.lock().unwrap().as_ref().unwrap()).is_some() {
         print!("Error: {}\n", (*err.lock().unwrap().as_ref().unwrap()));
     } else {
         print!("Parsed number: {}\n", (*num.lock().unwrap().as_ref().unwrap()));
     }
     println!("{}", "\n=== Named return values ===".to_string());
-    let (mut (*s.lock().unwrap().as_ref().unwrap()), mut (*p.lock().unwrap().as_ref().unwrap())) = calculate(std::sync::Arc::new(std::sync::Mutex::new(Some(6))), std::sync::Arc::new(std::sync::Mutex::new(Some(7))));
+    let (mut s, mut p) = calculate(std::sync::Arc::new(std::sync::Mutex::new(Some(6))), std::sync::Arc::new(std::sync::Mutex::new(Some(7))));
     print!("Sum: {}, Product: {}\n", (*s.lock().unwrap().as_ref().unwrap()), (*p.lock().unwrap().as_ref().unwrap()));
     let mut data = std::sync::Arc::new(std::sync::Mutex::new(Some(vec![3, 1, 4, 1, 5, 9, 2, 6])));
-    let (mut (*min.lock().unwrap().as_ref().unwrap()), mut (*max.lock().unwrap().as_ref().unwrap()), mut (*sum.lock().unwrap().as_ref().unwrap())) = process_data(std::sync::Arc::new(std::sync::Mutex::new(Some((*data.lock().unwrap().as_ref().unwrap())))));
+    let (mut min, mut max, mut sum) = process_data(std::sync::Arc::new(std::sync::Mutex::new(Some((*data.lock().unwrap().as_ref().unwrap())))));
     print!("Data: {}\n", (*data.lock().unwrap().as_ref().unwrap()));
     print!("Min: {}, Max: {}, Sum: {}\n", (*min.lock().unwrap().as_ref().unwrap()), (*max.lock().unwrap().as_ref().unwrap()), (*sum.lock().unwrap().as_ref().unwrap()));
     println!("{}", "\n=== Swapping values ===".to_string());
     let (mut (*x.lock().unwrap().as_ref().unwrap()), mut (*y.lock().unwrap().as_ref().unwrap())) = ("hello".to_string(), "world".to_string());
     print!("Before swap: x={}, y={}\n", (*x.lock().unwrap().as_ref().unwrap()), (*y.lock().unwrap().as_ref().unwrap()));
-    ((*x.lock().unwrap().as_ref().unwrap()), (*y.lock().unwrap().as_ref().unwrap())) = swap(std::sync::Arc::new(std::sync::Mutex::new(Some((*x.lock().unwrap().as_ref().unwrap())))), std::sync::Arc::new(std::sync::Mutex::new(Some((*y.lock().unwrap().as_ref().unwrap())))));
+    (x, y) = swap(std::sync::Arc::new(std::sync::Mutex::new(Some((*x.lock().unwrap().as_ref().unwrap())))), std::sync::Arc::new(std::sync::Mutex::new(Some((*y.lock().unwrap().as_ref().unwrap())))));
     print!("After swap: x={}, y={}\n", (*x.lock().unwrap().as_ref().unwrap()), (*y.lock().unwrap().as_ref().unwrap()));
     println!("{}", "\n=== Different types ===".to_string());
-    let (mut (*pName.lock().unwrap().as_ref().unwrap()), mut (*pAge.lock().unwrap().as_ref().unwrap()), mut (*pHeight.lock().unwrap().as_ref().unwrap()), mut (*pMarried.lock().unwrap().as_ref().unwrap())) = get_person_info();
+    let (mut pName, mut pAge, mut pHeight, mut pMarried) = get_person_info();
     print!("Person: {}, {} years old, {:.1} feet tall, married: {}\n", (*pName.lock().unwrap().as_ref().unwrap()), (*pAge.lock().unwrap().as_ref().unwrap()), (*pHeight.lock().unwrap().as_ref().unwrap()), (*pMarried.lock().unwrap().as_ref().unwrap()));
     println!("{}", "\n=== Finding in slice ===".to_string());
     let mut numbers = std::sync::Arc::new(std::sync::Mutex::new(Some(vec![10, 20, 30, 40, 50])));
-    let (mut (*index.lock().unwrap().as_ref().unwrap()), mut (*found.lock().unwrap().as_ref().unwrap())) = find_in_slice(std::sync::Arc::new(std::sync::Mutex::new(Some((*numbers.lock().unwrap().as_ref().unwrap())))), std::sync::Arc::new(std::sync::Mutex::new(Some(30))));
+    let (mut index, mut found) = find_in_slice(std::sync::Arc::new(std::sync::Mutex::new(Some((*numbers.lock().unwrap().as_ref().unwrap())))), std::sync::Arc::new(std::sync::Mutex::new(Some(30))));
     if (*found.lock().unwrap().as_ref().unwrap()) {
         print!("Found 30 at index {}\n", (*index.lock().unwrap().as_ref().unwrap()));
     } else {
         println!("{}", "30 not found".to_string());
     }
-    ((*index.lock().unwrap().as_ref().unwrap()), (*found.lock().unwrap().as_ref().unwrap())) = find_in_slice(std::sync::Arc::new(std::sync::Mutex::new(Some((*numbers.lock().unwrap().as_ref().unwrap())))), std::sync::Arc::new(std::sync::Mutex::new(Some(99))));
+    (index, found) = find_in_slice(std::sync::Arc::new(std::sync::Mutex::new(Some((*numbers.lock().unwrap().as_ref().unwrap())))), std::sync::Arc::new(std::sync::Mutex::new(Some(99))));
     if (*found.lock().unwrap().as_ref().unwrap()) {
         print!("Found 99 at index {}\n", (*index.lock().unwrap().as_ref().unwrap()));
     } else {
         println!("{}", "99 not found".to_string());
     }
     println!("{}", "\n=== Safe division ===".to_string());
-    let (mut (*result.lock().unwrap().as_ref().unwrap()), mut (*err.lock().unwrap().as_ref().unwrap())) = safe_divide(std::sync::Arc::new(std::sync::Mutex::new(Some(10.0))), std::sync::Arc::new(std::sync::Mutex::new(Some(3.0))));
+    let (mut result, mut err) = safe_divide(std::sync::Arc::new(std::sync::Mutex::new(Some(10.0))), std::sync::Arc::new(std::sync::Mutex::new(Some(3.0))));
     if (*err.lock().unwrap().as_ref().unwrap()).is_some() {
         print!("Error: {}\n", (*err.lock().unwrap().as_ref().unwrap()));
     } else {
         print!("10.0 / 3.0 = {:.2}\n", (*result.lock().unwrap().as_ref().unwrap()));
     }
-    ((*result.lock().unwrap().as_ref().unwrap()), (*err.lock().unwrap().as_ref().unwrap())) = safe_divide(std::sync::Arc::new(std::sync::Mutex::new(Some(10.0))), std::sync::Arc::new(std::sync::Mutex::new(Some(0.0))));
+    (result, err) = safe_divide(std::sync::Arc::new(std::sync::Mutex::new(Some(10.0))), std::sync::Arc::new(std::sync::Mutex::new(Some(0.0))));
     if (*err.lock().unwrap().as_ref().unwrap()).is_some() {
         print!("Error: {}\n", (*err.lock().unwrap().as_ref().unwrap()));
     } else {
         print!("Result: {:.2}\n", (*result.lock().unwrap().as_ref().unwrap()));
     }
     println!("{}", "\n=== Ignoring return values ===".to_string());
-    let ((*_.lock().unwrap().as_ref().unwrap()), mut (*remainder2.lock().unwrap().as_ref().unwrap())) = divmod(std::sync::Arc::new(std::sync::Mutex::new(Some(23))), std::sync::Arc::new(std::sync::Mutex::new(Some(7))));
+    let (_, mut remainder2) = divmod(std::sync::Arc::new(std::sync::Mutex::new(Some(23))), std::sync::Arc::new(std::sync::Mutex::new(Some(7))));
     print!("23 mod 7 = {} (quotient ignored)\n", (*remainder2.lock().unwrap().as_ref().unwrap()));
-    let (mut (*name2.lock().unwrap().as_ref().unwrap()), (*_.lock().unwrap().as_ref().unwrap())) = get_name_age();
+    let (mut name2, _) = get_name_age();
     print!("Name only: {} (age ignored)\n", (*name2.lock().unwrap().as_ref().unwrap()));
     println!("{}", "\n=== Multiple assignment ===".to_string());
     let (mut (*a.lock().unwrap().as_ref().unwrap()), mut (*b.lock().unwrap().as_ref().unwrap()), mut (*c.lock().unwrap().as_ref().unwrap())) = (1, 2, 3);

--- a/tests/XFAIL/panic_recover/main.rs
+++ b/tests/XFAIL/panic_recover/main.rs
@@ -1,22 +1,22 @@
-pub fn safe_divide(a: std::sync::Arc<std::sync::Mutex<Option<f64>>>, b: std::sync::Arc<std::sync::Mutex<Option<f64>>>) -> (std::sync::Arc<std::sync::Mutex<Option<f64>>>, std::sync::Arc<std::sync::Mutex<Option<Option<Box<dyn std::error::Error + Send + Sync>>>>>) {
-    let mut result: std::sync::Arc<std::sync::Mutex<Option<f64>>> = 0.0;
-    let mut err: std::sync::Arc<std::sync::Mutex<Option<Option<Box<dyn std::error::Error + Send + Sync>>>>> = None;
+pub fn safe_divide(a: std::sync::Arc<std::sync::Mutex<Option<f64>>>, b: std::sync::Arc<std::sync::Mutex<Option<f64>>>) -> (std::sync::Arc<std::sync::Mutex<Option<f64>>>, std::sync::Arc<std::sync::Mutex<Option<Box<dyn std::error::Error + Send + Sync>>>>) {
+    let mut result: std::sync::Arc<std::sync::Mutex<Option<f64>>> = std::sync::Arc::new(std::sync::Mutex::new(Some(0.0)));
+    let mut err: std::sync::Arc<std::sync::Mutex<Option<Box<dyn std::error::Error + Send + Sync>>>> = std::sync::Arc::new(std::sync::Mutex::new(None));
 
     
     if (*b.lock().unwrap().as_ref().unwrap()) == 0 {
         panic(std::sync::Arc::new(std::sync::Mutex::new(Some("division by zero".to_string()))));
     }
     { let new_val = (*a.lock().unwrap().as_ref().unwrap()) / (*b.lock().unwrap().as_ref().unwrap()); *result.lock().unwrap() = Some(new_val); };
-    return (std::sync::Arc::new(std::sync::Mutex::new(Some((*result.lock().unwrap().as_ref().unwrap()).clone()))), std::sync::Arc::new(std::sync::Mutex::new(Some(None))));
+    return (std::sync::Arc::new(std::sync::Mutex::new(Some((*result.lock().unwrap().as_ref().unwrap()).clone()))), std::sync::Arc::new(std::sync::Mutex::new(None)));
 }
 
-pub fn process_slice(slice: std::sync::Arc<std::sync::Mutex<Option<Vec<i32>>>>, index: std::sync::Arc<std::sync::Mutex<Option<i32>>>) -> (std::sync::Arc<std::sync::Mutex<Option<i32>>>, std::sync::Arc<std::sync::Mutex<Option<Option<Box<dyn std::error::Error + Send + Sync>>>>>) {
-    let mut value: std::sync::Arc<std::sync::Mutex<Option<i32>>> = 0;
-    let mut err: std::sync::Arc<std::sync::Mutex<Option<Option<Box<dyn std::error::Error + Send + Sync>>>>> = None;
+pub fn process_slice(slice: std::sync::Arc<std::sync::Mutex<Option<Vec<i32>>>>, index: std::sync::Arc<std::sync::Mutex<Option<i32>>>) -> (std::sync::Arc<std::sync::Mutex<Option<i32>>>, std::sync::Arc<std::sync::Mutex<Option<Box<dyn std::error::Error + Send + Sync>>>>) {
+    let mut value: std::sync::Arc<std::sync::Mutex<Option<i32>>> = std::sync::Arc::new(std::sync::Mutex::new(Some(0)));
+    let mut err: std::sync::Arc<std::sync::Mutex<Option<Box<dyn std::error::Error + Send + Sync>>>> = std::sync::Arc::new(std::sync::Mutex::new(None));
 
     
     { let new_val = (*slice.lock().unwrap().as_ref().unwrap())[(*index.lock().unwrap().as_ref().unwrap())]; *value.lock().unwrap() = Some(new_val); };
-    return (std::sync::Arc::new(std::sync::Mutex::new(Some((*value.lock().unwrap().as_ref().unwrap()).clone()))), std::sync::Arc::new(std::sync::Mutex::new(Some(None))));
+    return (std::sync::Arc::new(std::sync::Mutex::new(Some((*value.lock().unwrap().as_ref().unwrap()).clone()))), std::sync::Arc::new(std::sync::Mutex::new(None)));
 }
 
 pub fn nested_panic() {
@@ -41,13 +41,13 @@ pub fn chained_defers() {
 
 fn main() {
     println!("{}", "=== Safe divide examples ===".to_string());
-    let (mut (*result.lock().unwrap().as_ref().unwrap()), mut (*err.lock().unwrap().as_ref().unwrap())) = safe_divide(std::sync::Arc::new(std::sync::Mutex::new(Some(10))), std::sync::Arc::new(std::sync::Mutex::new(Some(2))));
+    let (mut result, mut err) = safe_divide(std::sync::Arc::new(std::sync::Mutex::new(Some(10))), std::sync::Arc::new(std::sync::Mutex::new(Some(2))));
     if (*err.lock().unwrap().as_ref().unwrap()).is_some() {
         print!("Error: {}\n", (*err.lock().unwrap().as_ref().unwrap()));
     } else {
         print!("10 / 2 = {:.2}\n", (*result.lock().unwrap().as_ref().unwrap()));
     }
-    ((*result.lock().unwrap().as_ref().unwrap()), (*err.lock().unwrap().as_ref().unwrap())) = safe_divide(std::sync::Arc::new(std::sync::Mutex::new(Some(10))), std::sync::Arc::new(std::sync::Mutex::new(Some(0))));
+    (result, err) = safe_divide(std::sync::Arc::new(std::sync::Mutex::new(Some(10))), std::sync::Arc::new(std::sync::Mutex::new(Some(0))));
     if (*err.lock().unwrap().as_ref().unwrap()).is_some() {
         print!("Error: {}\n", (*err.lock().unwrap().as_ref().unwrap()));
     } else {
@@ -55,13 +55,13 @@ fn main() {
     }
     println!("{}", "\n=== Slice access examples ===".to_string());
     let mut numbers = std::sync::Arc::new(std::sync::Mutex::new(Some(vec![1, 2, 3, 4, 5])));
-    let (mut (*value.lock().unwrap().as_ref().unwrap()), mut (*err.lock().unwrap().as_ref().unwrap())) = process_slice(std::sync::Arc::new(std::sync::Mutex::new(Some((*numbers.lock().unwrap().as_ref().unwrap())))), std::sync::Arc::new(std::sync::Mutex::new(Some(2))));
+    let (mut value, mut err) = process_slice(std::sync::Arc::new(std::sync::Mutex::new(Some((*numbers.lock().unwrap().as_ref().unwrap())))), std::sync::Arc::new(std::sync::Mutex::new(Some(2))));
     if (*err.lock().unwrap().as_ref().unwrap()).is_some() {
         print!("Error: {}\n", (*err.lock().unwrap().as_ref().unwrap()));
     } else {
         print!("numbers[2] = {}\n", (*value.lock().unwrap().as_ref().unwrap()));
     }
-    ((*value.lock().unwrap().as_ref().unwrap()), (*err.lock().unwrap().as_ref().unwrap())) = process_slice(std::sync::Arc::new(std::sync::Mutex::new(Some((*numbers.lock().unwrap().as_ref().unwrap())))), std::sync::Arc::new(std::sync::Mutex::new(Some(10))));
+    (value, err) = process_slice(std::sync::Arc::new(std::sync::Mutex::new(Some((*numbers.lock().unwrap().as_ref().unwrap())))), std::sync::Arc::new(std::sync::Mutex::new(Some(10))));
     if (*err.lock().unwrap().as_ref().unwrap()).is_some() {
         print!("Error: {}\n", (*err.lock().unwrap().as_ref().unwrap()));
     } else {

--- a/tests/XFAIL/stdlib_imports/main.rs
+++ b/tests/XFAIL/stdlib_imports/main.rs
@@ -13,7 +13,7 @@ fn main() {
     let mut num = std::sync::Arc::new(std::sync::Mutex::new(Some(42)));
     let mut str = (*num.lock().unwrap().as_ref().unwrap()).to_string();
     println!("{} {}", "Number as string:".to_string(), (*str.lock().unwrap().as_ref().unwrap()));
-    let (mut (*parsed.lock().unwrap().as_ref().unwrap()), mut (*err.lock().unwrap().as_ref().unwrap())) = match "123".to_string().parse::<i32>() { Ok(n) => (n, None), Err(e) => (0, Some(Box::new(e) as Box<dyn std::error::Error + Send + Sync>)) };
+    let (mut parsed, mut err) = match "123".to_string().parse::<i32>() { Ok(n) => (std::sync::Arc::new(std::sync::Mutex::new(Some(n))), std::sync::Arc::new(std::sync::Mutex::new(None))), Err(e) => (std::sync::Arc::new(std::sync::Mutex::new(Some(Box::new(e) as Box<dyn std::error::Error + Send + Sync>)))) };
     if (*err.lock().unwrap().as_ref().unwrap()).is_some() {
         println!("{} {}", "Parse error:".to_string(), (*err.lock().unwrap().as_ref().unwrap()));
     } else {
@@ -37,7 +37,7 @@ fn main() {
     (*time.lock().unwrap().as_ref().unwrap()).sleep(std::sync::Arc::new(std::sync::Mutex::new(Some(100 * (*time.lock().unwrap().as_ref().unwrap()).millisecond))));
     println!("{}", "Done sleeping".to_string());
     println!("{}", "\n--- os package ---".to_string());
-    let (mut (*hostname.lock().unwrap().as_ref().unwrap()), mut (*err.lock().unwrap().as_ref().unwrap())) = (*os.lock().unwrap().as_ref().unwrap()).hostname();
+    let (mut hostname, mut err) = (*os.lock().unwrap().as_ref().unwrap()).hostname();
     if (*err.lock().unwrap().as_ref().unwrap()).is_some() {
         println!("{} {}", "Hostname error:".to_string(), (*err.lock().unwrap().as_ref().unwrap()));
     } else {
@@ -49,7 +49,7 @@ fn main() {
     } else {
         println!("{}", "PATH not found".to_string());
     }
-    let (mut (*wd.lock().unwrap().as_ref().unwrap()), mut (*err.lock().unwrap().as_ref().unwrap())) = (*os.lock().unwrap().as_ref().unwrap()).getwd();
+    let (mut wd, mut err) = (*os.lock().unwrap().as_ref().unwrap()).getwd();
     if (*err.lock().unwrap().as_ref().unwrap()).is_some() {
         println!("{} {}", "Working directory error:".to_string(), (*err.lock().unwrap().as_ref().unwrap()));
     } else {

--- a/tests/XFAIL/type_assertion_simple/main.rs
+++ b/tests/XFAIL/type_assertion_simple/main.rs
@@ -1,12 +1,12 @@
 fn main() {
     let mut x = std::sync::Arc::new(std::sync::Mutex::new(Some("hello".to_string())));
-    let (mut (*s.lock().unwrap().as_ref().unwrap()), mut (*ok.lock().unwrap().as_ref().unwrap())) = match (*x.lock().unwrap().as_ref().unwrap()).downcast_ref::<String>() { Some(v) => (v.clone(), true), None => (String::new(), false) };
+    let (mut s, mut ok) = match (*x.lock().unwrap().as_ref().unwrap()).downcast_ref::<String>() { Some(v) => (v.clone(), true), None => (String::new(), false) };
     if (*ok.lock().unwrap().as_ref().unwrap()) {
         println!("{} {}", "x is string:".to_string(), (*s.lock().unwrap().as_ref().unwrap()));
     }
     let mut str = std::sync::Arc::new(std::sync::Mutex::new(Some(match (*x.lock().unwrap().as_ref().unwrap()).downcast_ref::<String>() { Some(v) => (v.clone(), true), None => (String::new(), false) })));
     println!("{} {}", "Asserted string:".to_string(), (*str.lock().unwrap().as_ref().unwrap()));
-    let (mut (*n.lock().unwrap().as_ref().unwrap()), mut (*ok.lock().unwrap().as_ref().unwrap())) = match (*x.lock().unwrap().as_ref().unwrap()).downcast_ref::<i32>() { Some(v) => (v.clone(), true), None => (0, false) };
+    let (mut n, mut ok) = match (*x.lock().unwrap().as_ref().unwrap()).downcast_ref::<i32>() { Some(v) => (v.clone(), true), None => (0, false) };
     if (*ok.lock().unwrap().as_ref().unwrap()) {
         println!("{} {}", "x is int:".to_string(), (*n.lock().unwrap().as_ref().unwrap()));
     } else {

--- a/tests/XFAIL/type_assertions/main.rs
+++ b/tests/XFAIL/type_assertions/main.rs
@@ -1,15 +1,15 @@
 pub fn process_value(value: std::sync::Arc<std::sync::Mutex<Option<Box<dyn std::any::Any>>>>) {
-    let (mut (*str.lock().unwrap().as_ref().unwrap()), mut (*ok.lock().unwrap().as_ref().unwrap())) = match (*value.lock().unwrap().as_ref().unwrap()).downcast_ref::<String>() { Some(v) => (v.clone(), true), None => (String::new(), false) };
+    let (mut str, mut ok) = match (*value.lock().unwrap().as_ref().unwrap()).downcast_ref::<String>() { Some(v) => (v.clone(), true), None => (String::new(), false) };
     if (*ok.lock().unwrap().as_ref().unwrap()) {
         print!("String value: {} (length: {})\n", (*str.lock().unwrap().as_ref().unwrap()), (*str.lock().unwrap().as_ref().unwrap()).len());
         return;
     }
-    let (mut (*num.lock().unwrap().as_ref().unwrap()), mut (*ok.lock().unwrap().as_ref().unwrap())) = match (*value.lock().unwrap().as_ref().unwrap()).downcast_ref::<i32>() { Some(v) => (v.clone(), true), None => (0, false) };
+    let (mut num, mut ok) = match (*value.lock().unwrap().as_ref().unwrap()).downcast_ref::<i32>() { Some(v) => (v.clone(), true), None => (0, false) };
     if (*ok.lock().unwrap().as_ref().unwrap()) {
         print!("Integer value: {} (doubled: {})\n", (*num.lock().unwrap().as_ref().unwrap()), (*num.lock().unwrap().as_ref().unwrap()) * 2);
         return;
     }
-    let (mut (*f.lock().unwrap().as_ref().unwrap()), mut (*ok.lock().unwrap().as_ref().unwrap())) = match (*value.lock().unwrap().as_ref().unwrap()).downcast_ref::<f64>() { Some(v) => (v.clone(), true), None => (0.0, false) };
+    let (mut f, mut ok) = match (*value.lock().unwrap().as_ref().unwrap()).downcast_ref::<f64>() { Some(v) => (v.clone(), true), None => (0.0, false) };
     if (*ok.lock().unwrap().as_ref().unwrap()) {
         print!("Float value: {:.2} (squared: {:.2})\n", (*f.lock().unwrap().as_ref().unwrap()), (*f.lock().unwrap().as_ref().unwrap()) * (*f.lock().unwrap().as_ref().unwrap()));
         return;
@@ -48,10 +48,10 @@ pub fn area() -> std::sync::Arc<std::sync::Mutex<Option<f64>>> {
 
 pub fn describe_shape(s: std::sync::Arc<std::sync::Mutex<Option<Shape>>>) {
     print!("Shape area: {:.2}\n", (*s.lock().unwrap().as_ref().unwrap()).area());
-    let (mut (*rect.lock().unwrap().as_ref().unwrap()), mut (*ok.lock().unwrap().as_ref().unwrap())) = match (*s.lock().unwrap().as_ref().unwrap()).downcast_ref::<Rectangle>() { Some(v) => (v.clone(), true), None => (Default::default(), false) };
+    let (mut rect, mut ok) = match (*s.lock().unwrap().as_ref().unwrap()).downcast_ref::<Rectangle>() { Some(v) => (v.clone(), true), None => (Default::default(), false) };
     if (*ok.lock().unwrap().as_ref().unwrap()) {
         print!("  Rectangle: {:.1} x {:.1}\n", (*rect.lock().unwrap().as_ref().unwrap()).width, (*rect.lock().unwrap().as_ref().unwrap()).height);
-    } else let (mut (*circle.lock().unwrap().as_ref().unwrap()), mut (*ok.lock().unwrap().as_ref().unwrap())) = match (*s.lock().unwrap().as_ref().unwrap()).downcast_ref::<Circle>() { Some(v) => (v.clone(), true), None => (Default::default(), false) };
+    } else let (mut circle, mut ok) = match (*s.lock().unwrap().as_ref().unwrap()).downcast_ref::<Circle>() { Some(v) => (v.clone(), true), None => (Default::default(), false) };
     if (*ok.lock().unwrap().as_ref().unwrap()) {
         print!("  Circle: radius {:.1}\n", (*circle.lock().unwrap().as_ref().unwrap()).radius);
     }

--- a/tests/XFAIL/type_conversions/main.rs
+++ b/tests/XFAIL/type_conversions/main.rs
@@ -65,14 +65,14 @@ fn main() {
     let mut any = std::sync::Arc::new(std::sync::Mutex::new(Some(42)));
     print!("interface{} value: {}\n", (*any.lock().unwrap().as_ref().unwrap()));
     print!("interface{} type: %T\n", (*any.lock().unwrap().as_ref().unwrap()));
-    let (mut (*intVal.lock().unwrap().as_ref().unwrap()), mut (*ok.lock().unwrap().as_ref().unwrap())) = match (*any.lock().unwrap().as_ref().unwrap()).downcast_ref::<i32>() { Some(v) => (v.clone(), true), None => (0, false) };
+    let (mut intVal, mut ok) = match (*any.lock().unwrap().as_ref().unwrap()).downcast_ref::<i32>() { Some(v) => (v.clone(), true), None => (0, false) };
     if (*ok.lock().unwrap().as_ref().unwrap()) {
         print!("asserted as int: {}\n", (*intVal.lock().unwrap().as_ref().unwrap()));
     }
     { let new_val = "hello".to_string(); *any.lock().unwrap() = Some(new_val); };
     print!("new interface{} value: {}\n", (*any.lock().unwrap().as_ref().unwrap()));
     print!("new interface{} type: %T\n", (*any.lock().unwrap().as_ref().unwrap()));
-    let (mut (*strVal.lock().unwrap().as_ref().unwrap()), mut (*ok.lock().unwrap().as_ref().unwrap())) = match (*any.lock().unwrap().as_ref().unwrap()).downcast_ref::<String>() { Some(v) => (v.clone(), true), None => (String::new(), false) };
+    let (mut strVal, mut ok) = match (*any.lock().unwrap().as_ref().unwrap()).downcast_ref::<String>() { Some(v) => (v.clone(), true), None => (String::new(), false) };
     if (*ok.lock().unwrap().as_ref().unwrap()) {
         print!("asserted as string: {}\n", (*strVal.lock().unwrap().as_ref().unwrap()));
     }


### PR DESCRIPTION
Fixes constant declarations to use base types without wrapping.

- Constants now use base types without Arc<Mutex<Option<>>> wrapping
- Add support for local constants in functions  
- Track local constants to avoid unwrapping them like variables
- Keep original case for local constants (no uppercase conversion)
- Improve type inference for const expressions

Constants now work for basic cases. Complex cases like string concatenation in const context still need work due to Rust limitations.

Based on #1