### PR TITLE
feat: Add method receiver support

### DIFF
--- a/go/expr.go
+++ b/go/expr.go
@@ -34,6 +34,9 @@ func TranspileExpressionContext(out *strings.Builder, expr ast.Expr, ctx ExprCon
 	case *ast.Ident:
 		if e.Name == "nil" {
 			out.WriteString("None")
+		} else if currentReceiver != "" && e.Name == currentReceiver {
+			// Method receiver - translate to self
+			out.WriteString("self")
 		} else if e.Name[0] >= 'A' && e.Name[0] <= 'Z' && e.Name != "String" {
 			// Likely a constant - convert to UPPER_SNAKE_CASE
 			out.WriteString(strings.ToUpper(ToSnakeCase(e.Name)))

--- a/go/transpile.go
+++ b/go/transpile.go
@@ -10,42 +10,106 @@ import (
 var rangeLoopVars = make(map[string]string)
 var localConstants = make(map[string]string)
 
+// currentReceiver tracks the current method receiver name for self translation
+var currentReceiver string
+
+// getReceiverType extracts the type name from a receiver type expression
+func getReceiverType(expr ast.Expr) string {
+	switch t := expr.(type) {
+	case *ast.Ident:
+		return t.Name
+	case *ast.StarExpr:
+		// Pointer receiver
+		if ident, ok := t.X.(*ast.Ident); ok {
+			return ident.Name
+		}
+	}
+	return "Unknown"
+}
+
 func Transpile(file *ast.File) string {
 	var output strings.Builder
+
+	// Collect methods by receiver type
+	methods := make(map[string][]*ast.FuncDecl)
+	var functions []*ast.FuncDecl
+	var types []*ast.TypeSpec
+	var consts []*ast.GenDecl
+
+	// First pass: categorize declarations
+	for _, decl := range file.Decls {
+		switch d := decl.(type) {
+		case *ast.FuncDecl:
+			if d.Recv != nil && len(d.Recv.List) > 0 {
+				// This is a method
+				recvType := getReceiverType(d.Recv.List[0].Type)
+				methods[recvType] = append(methods[recvType], d)
+			} else {
+				// Regular function
+				functions = append(functions, d)
+			}
+		case *ast.GenDecl:
+			switch d.Tok {
+			case token.TYPE:
+				for _, spec := range d.Specs {
+					if typeSpec, ok := spec.(*ast.TypeSpec); ok {
+						types = append(types, typeSpec)
+					}
+				}
+			case token.CONST:
+				consts = append(consts, d)
+			}
+		}
+	}
 
 	// Track if we need spacing between declarations
 	first := true
 
-	for _, decl := range file.Decls {
-		switch d := decl.(type) {
-		case *ast.FuncDecl:
-			if !first {
-				output.WriteString("\n\n")
-			}
-			first = false
-			TranspileFunction(&output, d)
-		case *ast.GenDecl:
-			switch d.Tok {
-			case token.TYPE:
-				// Handle type declarations
-				for _, spec := range d.Specs {
-					if typeSpec, ok := spec.(*ast.TypeSpec); ok {
-						if !first {
-							output.WriteString("\n\n")
-						}
-						first = false
-						TranspileTypeDecl(&output, typeSpec)
-					}
-				}
-			case token.CONST:
-				// Handle const declarations
-				if !first {
-					output.WriteString("\n\n")
-				}
-				first = false
-				TranspileConstDecl(&output, d)
-			}
+	// Output constants first
+	for _, c := range consts {
+		if !first {
+			output.WriteString("\n\n")
 		}
+		first = false
+		TranspileConstDecl(&output, c)
+	}
+
+	// Output type declarations
+	for _, t := range types {
+		if !first {
+			output.WriteString("\n\n")
+		}
+		first = false
+		TranspileTypeDecl(&output, t)
+	}
+
+	// Output impl blocks for types with methods
+	for typeName, typeMethods := range methods {
+		if !first {
+			output.WriteString("\n\n")
+		}
+		first = false
+		output.WriteString("impl ")
+		output.WriteString(typeName)
+		output.WriteString(" {\n")
+
+		for i, method := range typeMethods {
+			if i > 0 {
+				output.WriteString("\n")
+			}
+			TranspileMethodImpl(&output, method)
+		}
+
+		output.WriteString("}")
+	}
+
+	// Output regular functions
+	for _, fn := range functions {
+		if !first {
+			output.WriteString("\n\n")
+		}
+		first = false
+		TranspileFunction(&output, fn)
 	}
 
 	return output.String()

--- a/tests/XFAIL/embedded_structs/main.rs
+++ b/tests/XFAIL/embedded_structs/main.rs
@@ -4,25 +4,11 @@ struct Person {
     age: std::sync::Arc<std::sync::Mutex<Option<i32>>>,
 }
 
-pub fn greet() {
-    print!("Hello, I'm {}\n", (*p.lock().unwrap().as_ref().unwrap()).name);
-}
-
-pub fn get_info() -> std::sync::Arc<std::sync::Mutex<Option<String>>> {
-
-    return std::sync::Arc::new(std::sync::Mutex::new(Some((*fmt.lock().unwrap().as_ref().unwrap()).sprintf(std::sync::Arc::new(std::sync::Mutex::new(Some("%s (%d years old)".to_string()))), std::sync::Arc::new(std::sync::Mutex::new(Some((*p.lock().unwrap().as_ref().unwrap()).name))), std::sync::Arc::new(std::sync::Mutex::new(Some((*p.lock().unwrap().as_ref().unwrap()).age)))))));
-}
-
 #[derive(Debug)]
 struct Address {
     street: std::sync::Arc<std::sync::Mutex<Option<String>>>,
     city: std::sync::Arc<std::sync::Mutex<Option<String>>>,
     state: std::sync::Arc<std::sync::Mutex<Option<String>>>,
-}
-
-pub fn full_address() -> std::sync::Arc<std::sync::Mutex<Option<String>>> {
-
-    return std::sync::Arc::new(std::sync::Mutex::new(Some((*fmt.lock().unwrap().as_ref().unwrap()).sprintf(std::sync::Arc::new(std::sync::Mutex::new(Some("%s, %s, %s".to_string()))), std::sync::Arc::new(std::sync::Mutex::new(Some((*a.lock().unwrap().as_ref().unwrap()).street))), std::sync::Arc::new(std::sync::Mutex::new(Some((*a.lock().unwrap().as_ref().unwrap()).city))), std::sync::Arc::new(std::sync::Mutex::new(Some((*a.lock().unwrap().as_ref().unwrap()).state)))))));
 }
 
 #[derive(Debug)]
@@ -33,18 +19,10 @@ struct Employee {
     salary: std::sync::Arc<std::sync::Mutex<Option<f64>>>,
 }
 
-pub fn work() {
-    print!("{} is working (ID: {})\n", (*e.lock().unwrap().as_ref().unwrap()).name, (*e.lock().unwrap().as_ref().unwrap()).i_d);
-}
-
 #[derive(Debug)]
 struct Manager {
     std::sync::_arc<std::sync::_mutex<_option<_employee>>>: std::sync::Arc<std::sync::Mutex<Option<Employee>>>,
     team: std::sync::Arc<std::sync::Mutex<Option<Vec<String>>>>,
-}
-
-pub fn manage() {
-    print!("Manager {} is managing team: {}\n", (*m.lock().unwrap().as_ref().unwrap()).name, (*m.lock().unwrap().as_ref().unwrap()).team);
 }
 
 #[derive(Debug)]
@@ -57,6 +35,34 @@ struct CompanyInfo {
 struct Company {
     name: std::sync::Arc<std::sync::Mutex<Option<String>>>,
     std::sync::_arc<std::sync::_mutex<_option<_company_info>>>: std::sync::Arc<std::sync::Mutex<Option<CompanyInfo>>>,
+}
+
+impl Person {
+    pub fn greet(&self) {
+        print!("Hello, I'm {}\n", self.name);
+    }
+
+    pub fn get_info(&self) -> std::sync::Arc<std::sync::Mutex<Option<String>>> {
+        return std::sync::Arc::new(std::sync::Mutex::new(Some((*fmt.lock().unwrap().as_ref().unwrap()).sprintf(std::sync::Arc::new(std::sync::Mutex::new(Some("%s (%d years old)".to_string()))), std::sync::Arc::new(std::sync::Mutex::new(Some(self.name))), std::sync::Arc::new(std::sync::Mutex::new(Some(self.age)))))));
+    }
+}
+
+impl Address {
+    pub fn full_address(&self) -> std::sync::Arc<std::sync::Mutex<Option<String>>> {
+        return std::sync::Arc::new(std::sync::Mutex::new(Some((*fmt.lock().unwrap().as_ref().unwrap()).sprintf(std::sync::Arc::new(std::sync::Mutex::new(Some("%s, %s, %s".to_string()))), std::sync::Arc::new(std::sync::Mutex::new(Some(self.street))), std::sync::Arc::new(std::sync::Mutex::new(Some(self.city))), std::sync::Arc::new(std::sync::Mutex::new(Some(self.state)))))));
+    }
+}
+
+impl Employee {
+    pub fn work(&self) {
+        print!("{} is working (ID: {})\n", self.name, self.i_d);
+    }
+}
+
+impl Manager {
+    pub fn manage(&self) {
+        print!("Manager {} is managing team: {}\n", self.name, self.team);
+    }
 }
 
 fn main() {

--- a/tests/XFAIL/error_handling/main.rs
+++ b/tests/XFAIL/error_handling/main.rs
@@ -1,3 +1,15 @@
+#[derive(Debug)]
+struct CustomError {
+    code: std::sync::Arc<std::sync::Mutex<Option<i32>>>,
+    message: std::sync::Arc<std::sync::Mutex<Option<String>>>,
+}
+
+impl CustomError {
+    pub fn error(&self) -> std::sync::Arc<std::sync::Mutex<Option<String>>> {
+        return std::sync::Arc::new(std::sync::Mutex::new(Some((*fmt.lock().unwrap().as_ref().unwrap()).sprintf(std::sync::Arc::new(std::sync::Mutex::new(Some("Error %d: %s".to_string()))), std::sync::Arc::new(std::sync::Mutex::new(Some(self.code))), std::sync::Arc::new(std::sync::Mutex::new(Some(self.message)))))));
+    }
+}
+
 pub fn divide(a: std::sync::Arc<std::sync::Mutex<Option<f64>>>, b: std::sync::Arc<std::sync::Mutex<Option<f64>>>) -> (std::sync::Arc<std::sync::Mutex<Option<f64>>>, std::sync::Arc<std::sync::Mutex<Option<Box<dyn std::error::Error + Send + Sync>>>>) {
 
     if (*b.lock().unwrap().as_ref().unwrap()) == 0 {
@@ -18,17 +30,6 @@ pub fn sqrt(x: std::sync::Arc<std::sync::Mutex<Option<f64>>>) -> (std::sync::Arc
         { let mut guard = i.lock().unwrap(); *guard = Some(guard.as_ref().unwrap() + 1); }
     }
     return (std::sync::Arc::new(std::sync::Mutex::new(Some((*result.lock().unwrap().as_ref().unwrap()).clone()))), std::sync::Arc::new(std::sync::Mutex::new(None)));
-}
-
-#[derive(Debug)]
-struct CustomError {
-    code: std::sync::Arc<std::sync::Mutex<Option<i32>>>,
-    message: std::sync::Arc<std::sync::Mutex<Option<String>>>,
-}
-
-pub fn error() -> std::sync::Arc<std::sync::Mutex<Option<String>>> {
-
-    return std::sync::Arc::new(std::sync::Mutex::new(Some((*fmt.lock().unwrap().as_ref().unwrap()).sprintf(std::sync::Arc::new(std::sync::Mutex::new(Some("Error %d: %s".to_string()))), std::sync::Arc::new(std::sync::Mutex::new(Some((*e.lock().unwrap().as_ref().unwrap()).code))), std::sync::Arc::new(std::sync::Mutex::new(Some((*e.lock().unwrap().as_ref().unwrap()).message)))))));
 }
 
 pub fn process_value(val: std::sync::Arc<std::sync::Mutex<Option<i32>>>) -> std::sync::Arc<std::sync::Mutex<Option<Box<dyn std::error::Error + Send + Sync>>>> {

--- a/tests/XFAIL/function_types/main.rs
+++ b/tests/XFAIL/function_types/main.rs
@@ -6,6 +6,13 @@
 
 
 
+#[derive(Debug)]
+struct Calculator {
+    add: std::sync::Arc<std::sync::Mutex<Option<BinaryOp>>>,
+    subtract: std::sync::Arc<std::sync::Mutex<Option<BinaryOp>>>,
+    multiply: std::sync::Arc<std::sync::Mutex<Option<BinaryOp>>>,
+}
+
 pub fn add(a: std::sync::Arc<std::sync::Mutex<Option<i32>>>, b: std::sync::Arc<std::sync::Mutex<Option<i32>>>) -> std::sync::Arc<std::sync::Mutex<Option<i32>>> {
 
     return std::sync::Arc::new(std::sync::Mutex::new(Some((*a.lock().unwrap().as_ref().unwrap()) + (*b.lock().unwrap().as_ref().unwrap()))));
@@ -82,13 +89,6 @@ pub fn make_multiplier(factor: std::sync::Arc<std::sync::Mutex<Option<i32>>>) ->
 pub fn make_adder(addend: std::sync::Arc<std::sync::Mutex<Option<i32>>>) -> std::sync::Arc<std::sync::Mutex<Option<BinaryOp>>> {
 
     return std::sync::Arc::new(std::sync::Mutex::new(Some()));
-}
-
-#[derive(Debug)]
-struct Calculator {
-    add: std::sync::Arc<std::sync::Mutex<Option<BinaryOp>>>,
-    subtract: std::sync::Arc<std::sync::Mutex<Option<BinaryOp>>>,
-    multiply: std::sync::Arc<std::sync::Mutex<Option<BinaryOp>>>,
 }
 
 fn main() {

--- a/tests/XFAIL/init_functions/main.rs
+++ b/tests/XFAIL/init_functions/main.rs
@@ -1,3 +1,10 @@
+#[derive(Debug)]
+struct Config {
+    name: std::sync::Arc<std::sync::Mutex<Option<String>>>,
+    version: std::sync::Arc<std::sync::Mutex<Option<String>>>,
+    debug: std::sync::Arc<std::sync::Mutex<Option<bool>>>,
+}
+
 pub fn init() {
     println!("{}", "First init function called".to_string());
     { let new_val = 10; *globalCounter.lock().unwrap() = Some(new_val); };
@@ -31,13 +38,6 @@ pub fn init() {
     println!("{}", "Fourth init function called".to_string());
     print!("Computed value is: {}\n", (*computedValue.lock().unwrap().as_ref().unwrap()));
     (*computedValue.lock().unwrap().as_ref().unwrap()) += 10;
-}
-
-#[derive(Debug)]
-struct Config {
-    name: std::sync::Arc<std::sync::Mutex<Option<String>>>,
-    version: std::sync::Arc<std::sync::Mutex<Option<String>>>,
-    debug: std::sync::Arc<std::sync::Mutex<Option<bool>>>,
 }
 
 pub fn init() {

--- a/tests/XFAIL/interfaces_basic/main.rs
+++ b/tests/XFAIL/interfaces_basic/main.rs
@@ -6,29 +6,29 @@ struct Rectangle {
     height: std::sync::Arc<std::sync::Mutex<Option<f64>>>,
 }
 
-pub fn area() -> std::sync::Arc<std::sync::Mutex<Option<f64>>> {
-
-    return std::sync::Arc::new(std::sync::Mutex::new(Some((*r.lock().unwrap().as_ref().unwrap()).width * (*r.lock().unwrap().as_ref().unwrap()).height)));
-}
-
-pub fn perimeter() -> std::sync::Arc<std::sync::Mutex<Option<f64>>> {
-
-    return std::sync::Arc::new(std::sync::Mutex::new(Some(2 * )));
-}
-
 #[derive(Debug)]
 struct Circle {
     radius: std::sync::Arc<std::sync::Mutex<Option<f64>>>,
 }
 
-pub fn area() -> std::sync::Arc<std::sync::Mutex<Option<f64>>> {
+impl Rectangle {
+    pub fn area(&self) -> std::sync::Arc<std::sync::Mutex<Option<f64>>> {
+        return std::sync::Arc::new(std::sync::Mutex::new(Some(self.width * self.height)));
+    }
 
-    return std::sync::Arc::new(std::sync::Mutex::new(Some(3.14159 * (*c.lock().unwrap().as_ref().unwrap()).radius * (*c.lock().unwrap().as_ref().unwrap()).radius)));
+    pub fn perimeter(&self) -> std::sync::Arc<std::sync::Mutex<Option<f64>>> {
+        return std::sync::Arc::new(std::sync::Mutex::new(Some(2 * )));
+    }
 }
 
-pub fn perimeter() -> std::sync::Arc<std::sync::Mutex<Option<f64>>> {
+impl Circle {
+    pub fn area(&self) -> std::sync::Arc<std::sync::Mutex<Option<f64>>> {
+        return std::sync::Arc::new(std::sync::Mutex::new(Some(3.14159 * self.radius * self.radius)));
+    }
 
-    return std::sync::Arc::new(std::sync::Mutex::new(Some(2 * 3.14159 * (*c.lock().unwrap().as_ref().unwrap()).radius)));
+    pub fn perimeter(&self) -> std::sync::Arc<std::sync::Mutex<Option<f64>>> {
+        return std::sync::Arc::new(std::sync::Mutex::new(Some(2 * 3.14159 * self.radius)));
+    }
 }
 
 pub fn print_shape_info(s: std::sync::Arc<std::sync::Mutex<Option<Shape>>>) {

--- a/tests/XFAIL/methods/main.rs
+++ b/tests/XFAIL/methods/main.rs
@@ -3,13 +3,14 @@ struct Counter {
     value: std::sync::Arc<std::sync::Mutex<Option<i32>>>,
 }
 
-pub fn increment() {
-    { let mut guard = (*c.lock().unwrap().as_ref().unwrap()).value.lock().unwrap(); *guard = Some(guard.as_ref().unwrap() + 1); }
-}
+impl Counter {
+    pub fn increment(&mut self) {
+        { let mut guard = self.value.lock().unwrap(); *guard = Some(guard.as_ref().unwrap() + 1); }
+    }
 
-pub fn value() -> std::sync::Arc<std::sync::Mutex<Option<i32>>> {
-
-    return std::sync::Arc::new(std::sync::Mutex::new(Some((*c.lock().unwrap().as_ref().unwrap()).value)));
+    pub fn value(&mut self) -> std::sync::Arc<std::sync::Mutex<Option<i32>>> {
+        return std::sync::Arc::new(std::sync::Mutex::new(Some(self.value)));
+    }
 }
 
 pub fn new_counter() -> std::sync::Arc<std::sync::Mutex<Option<Counter>>> {

--- a/tests/XFAIL/methods_basic/main.rs
+++ b/tests/XFAIL/methods_basic/main.rs
@@ -3,38 +3,40 @@ struct Counter {
     value: std::sync::Arc<std::sync::Mutex<Option<i32>>>,
 }
 
-pub fn get_value() -> std::sync::Arc<std::sync::Mutex<Option<i32>>> {
-
-    return std::sync::Arc::new(std::sync::Mutex::new(Some((*c.lock().unwrap().as_ref().unwrap()).value)));
-}
-
-pub fn increment() {
-    { let mut guard = (*c.lock().unwrap().as_ref().unwrap()).value.lock().unwrap(); *guard = Some(guard.as_ref().unwrap() + 1); }
-}
-
-pub fn add(n: std::sync::Arc<std::sync::Mutex<Option<i32>>>) {
-    (*c.lock().unwrap().as_ref().unwrap()).value += (*n.lock().unwrap().as_ref().unwrap());
-}
-
-pub fn double() -> std::sync::Arc<std::sync::Mutex<Option<i32>>> {
-
-    (*c.lock().unwrap().as_ref().unwrap()).value = 2;
-    return std::sync::Arc::new(std::sync::Mutex::new(Some((*c.lock().unwrap().as_ref().unwrap()).value)));
-}
-
 #[derive(Debug)]
 struct Person {
     name: std::sync::Arc<std::sync::Mutex<Option<String>>>,
     age: std::sync::Arc<std::sync::Mutex<Option<i32>>>,
 }
 
-pub fn greet() {
-    print!("Hello, I'm {} and I'm {} years old\n", (*p.lock().unwrap().as_ref().unwrap()).name, (*p.lock().unwrap().as_ref().unwrap()).age);
+impl Counter {
+    pub fn get_value(&self) -> std::sync::Arc<std::sync::Mutex<Option<i32>>> {
+        return std::sync::Arc::new(std::sync::Mutex::new(Some(self.value)));
+    }
+
+    pub fn increment(&mut self) {
+        { let mut guard = self.value.lock().unwrap(); *guard = Some(guard.as_ref().unwrap() + 1); }
+    }
+
+    pub fn add(&mut self, n: std::sync::Arc<std::sync::Mutex<Option<i32>>>) {
+        self.value += (*n.lock().unwrap().as_ref().unwrap());
+    }
+
+    pub fn double(&mut self) -> std::sync::Arc<std::sync::Mutex<Option<i32>>> {
+        self.value = 2;
+        return std::sync::Arc::new(std::sync::Mutex::new(Some(self.value)));
+    }
 }
 
-pub fn have_birthday() {
-    { let mut guard = (*p.lock().unwrap().as_ref().unwrap()).age.lock().unwrap(); *guard = Some(guard.as_ref().unwrap() + 1); }
-    print!("{} is now {} years old\n", (*p.lock().unwrap().as_ref().unwrap()).name, (*p.lock().unwrap().as_ref().unwrap()).age);
+impl Person {
+    pub fn greet(&self) {
+        print!("Hello, I'm {} and I'm {} years old\n", self.name, self.age);
+    }
+
+    pub fn have_birthday(&mut self) {
+        { let mut guard = self.age.lock().unwrap(); *guard = Some(guard.as_ref().unwrap() + 1); }
+        print!("{} is now {} years old\n", self.name, self.age);
+    }
 }
 
 fn main() {

--- a/tests/XFAIL/nested_structures/main.rs
+++ b/tests/XFAIL/nested_structures/main.rs
@@ -5,20 +5,10 @@ struct Circle {
     radius: std::sync::Arc<std::sync::Mutex<Option<f64>>>,
 }
 
-pub fn draw() -> std::sync::Arc<std::sync::Mutex<Option<String>>> {
-
-    return std::sync::Arc::new(std::sync::Mutex::new(Some((*fmt.lock().unwrap().as_ref().unwrap()).sprintf(std::sync::Arc::new(std::sync::Mutex::new(Some("Circle(r=%.1f)".to_string()))), std::sync::Arc::new(std::sync::Mutex::new(Some((*c.lock().unwrap().as_ref().unwrap()).radius)))))));
-}
-
 #[derive(Debug)]
 struct Rectangle {
     width: std::sync::Arc<std::sync::Mutex<Option<f64>>>,
     height: std::sync::Arc<std::sync::Mutex<Option<f64>>>,
-}
-
-pub fn draw() -> std::sync::Arc<std::sync::Mutex<Option<String>>> {
-
-    return std::sync::Arc::new(std::sync::Mutex::new(Some((*fmt.lock().unwrap().as_ref().unwrap()).sprintf(std::sync::Arc::new(std::sync::Mutex::new(Some("Rectangle(%.1fx%.1f)".to_string()))), std::sync::Arc::new(std::sync::Mutex::new(Some((*r.lock().unwrap().as_ref().unwrap()).width))), std::sync::Arc::new(std::sync::Mutex::new(Some((*r.lock().unwrap().as_ref().unwrap()).height)))))));
 }
 
 #[derive(Debug)]
@@ -63,6 +53,18 @@ struct Company {
     name: std::sync::Arc<std::sync::Mutex<Option<String>>>,
     departments: std::sync::Arc<std::sync::Mutex<Option<Vec<Department>>>>,
     headquarters: std::sync::Arc<std::sync::Mutex<Option<Address>>>,
+}
+
+impl Circle {
+    pub fn draw(&self) -> std::sync::Arc<std::sync::Mutex<Option<String>>> {
+        return std::sync::Arc::new(std::sync::Mutex::new(Some((*fmt.lock().unwrap().as_ref().unwrap()).sprintf(std::sync::Arc::new(std::sync::Mutex::new(Some("Circle(r=%.1f)".to_string()))), std::sync::Arc::new(std::sync::Mutex::new(Some(self.radius)))))));
+    }
+}
+
+impl Rectangle {
+    pub fn draw(&self) -> std::sync::Arc<std::sync::Mutex<Option<String>>> {
+        return std::sync::Arc::new(std::sync::Mutex::new(Some((*fmt.lock().unwrap().as_ref().unwrap()).sprintf(std::sync::Arc::new(std::sync::Mutex::new(Some("Rectangle(%.1fx%.1f)".to_string()))), std::sync::Arc::new(std::sync::Mutex::new(Some(self.width))), std::sync::Arc::new(std::sync::Mutex::new(Some(self.height)))))));
+    }
 }
 
 fn main() {

--- a/tests/XFAIL/type_assertions/main.rs
+++ b/tests/XFAIL/type_assertions/main.rs
@@ -1,3 +1,28 @@
+
+
+#[derive(Debug)]
+struct Rectangle {
+    width: std::sync::Arc<std::sync::Mutex<Option<f64>>>,
+    height: std::sync::Arc<std::sync::Mutex<Option<f64>>>,
+}
+
+#[derive(Debug)]
+struct Circle {
+    radius: std::sync::Arc<std::sync::Mutex<Option<f64>>>,
+}
+
+impl Rectangle {
+    pub fn area(&self) -> std::sync::Arc<std::sync::Mutex<Option<f64>>> {
+        return std::sync::Arc::new(std::sync::Mutex::new(Some(self.width * self.height)));
+    }
+}
+
+impl Circle {
+    pub fn area(&self) -> std::sync::Arc<std::sync::Mutex<Option<f64>>> {
+        return std::sync::Arc::new(std::sync::Mutex::new(Some(3.14159 * self.radius * self.radius)));
+    }
+}
+
 pub fn process_value(value: std::sync::Arc<std::sync::Mutex<Option<Box<dyn std::any::Any>>>>) {
     let (mut str, mut ok) = match (*value.lock().unwrap().as_ref().unwrap()).downcast_ref::<String>() { Some(v) => (v.clone(), true), None => (String::new(), false) };
     if (*ok.lock().unwrap().as_ref().unwrap()) {
@@ -21,29 +46,6 @@ pub fn assert_without_check(value: std::sync::Arc<std::sync::Mutex<Option<Box<dy
     
     let mut str = std::sync::Arc::new(std::sync::Mutex::new(Some(match (*value.lock().unwrap().as_ref().unwrap()).downcast_ref::<String>() { Some(v) => (v.clone(), true), None => (String::new(), false) })));
     print!("Asserted string: {}\n", (*str.lock().unwrap().as_ref().unwrap()));
-}
-
-
-
-#[derive(Debug)]
-struct Rectangle {
-    width: std::sync::Arc<std::sync::Mutex<Option<f64>>>,
-    height: std::sync::Arc<std::sync::Mutex<Option<f64>>>,
-}
-
-pub fn area() -> std::sync::Arc<std::sync::Mutex<Option<f64>>> {
-
-    return std::sync::Arc::new(std::sync::Mutex::new(Some((*r.lock().unwrap().as_ref().unwrap()).width * (*r.lock().unwrap().as_ref().unwrap()).height)));
-}
-
-#[derive(Debug)]
-struct Circle {
-    radius: std::sync::Arc<std::sync::Mutex<Option<f64>>>,
-}
-
-pub fn area() -> std::sync::Arc<std::sync::Mutex<Option<f64>>> {
-
-    return std::sync::Arc::new(std::sync::Mutex::new(Some(3.14159 * (*c.lock().unwrap().as_ref().unwrap()).radius * (*c.lock().unwrap().as_ref().unwrap()).radius)));
 }
 
 pub fn describe_shape(s: std::sync::Arc<std::sync::Mutex<Option<Shape>>>) {


### PR DESCRIPTION
Adds basic support for Go methods with receivers.

- Collect methods by receiver type and generate impl blocks
- Support both value receivers (&self) and pointer receivers (&mut self)  
- Translate receiver parameter name to 'self' in method bodies
- Handle method declarations with proper Rust syntax

Methods now have basic structure working. Field access and method calls still need refinement for proper wrapping/unwrapping semantics.

Based on #2