### PR TITLE
feat: Complete blank identifier support

### DIFF
--- a/go/expr.go
+++ b/go/expr.go
@@ -40,7 +40,7 @@ func TranspileExpressionContext(out *strings.Builder, expr ast.Expr, ctx ExprCon
 		} else if e.Name[0] >= 'A' && e.Name[0] <= 'Z' && e.Name != "String" {
 			// Likely a constant - convert to UPPER_SNAKE_CASE
 			out.WriteString(strings.ToUpper(ToSnakeCase(e.Name)))
-		} else if e.Name == "true" || e.Name == "false" {
+		} else if e.Name == "true" || e.Name == "false" || e.Name == "_" {
 			out.WriteString(e.Name)
 		} else if _, isRangeVar := rangeLoopVars[e.Name]; isRangeVar {
 			out.WriteString(e.Name)

--- a/tests/XFAIL/blank_identifier/main.rs
+++ b/tests/XFAIL/blank_identifier/main.rs
@@ -59,7 +59,7 @@ fn main() {
     print!("Count (ignoring sum): {}\n", (*count.lock().unwrap().as_ref().unwrap()));
     println!("{}", "\n=== Blank identifier in declarations ===".to_string());
     let _ = "This string is assigned but not used".to_string();
-    let (mut (*a.lock().unwrap().as_ref().unwrap()), (*_.lock().unwrap().as_ref().unwrap()), mut (*c.lock().unwrap().as_ref().unwrap())) = (1, 2, 3);
+    let (mut (*a.lock().unwrap().as_ref().unwrap()), _, mut (*c.lock().unwrap().as_ref().unwrap())) = (1, 2, 3);
     print!("a={}, c={} (middle value ignored)\n", (*a.lock().unwrap().as_ref().unwrap()), (*c.lock().unwrap().as_ref().unwrap()));
     println!("{}", "\n=== Blank identifier with type assertion ===".to_string());
     let mut value = std::sync::Arc::new(std::sync::Mutex::new(Some("hello world".to_string())));

--- a/tests/XFAIL/embedded_structs/main.rs
+++ b/tests/XFAIL/embedded_structs/main.rs
@@ -37,6 +37,18 @@ struct Company {
     std::sync::_arc<std::sync::_mutex<_option<_company_info>>>: std::sync::Arc<std::sync::Mutex<Option<CompanyInfo>>>,
 }
 
+impl Employee {
+    pub fn work(&self) {
+        print!("{} is working (ID: {})\n", self.name, self.i_d);
+    }
+}
+
+impl Manager {
+    pub fn manage(&self) {
+        print!("Manager {} is managing team: {}\n", self.name, self.team);
+    }
+}
+
 impl Person {
     pub fn greet(&self) {
         print!("Hello, I'm {}\n", self.name);
@@ -50,18 +62,6 @@ impl Person {
 impl Address {
     pub fn full_address(&self) -> std::sync::Arc<std::sync::Mutex<Option<String>>> {
         return std::sync::Arc::new(std::sync::Mutex::new(Some((*fmt.lock().unwrap().as_ref().unwrap()).sprintf(std::sync::Arc::new(std::sync::Mutex::new(Some("%s, %s, %s".to_string()))), std::sync::Arc::new(std::sync::Mutex::new(Some(self.street))), std::sync::Arc::new(std::sync::Mutex::new(Some(self.city))), std::sync::Arc::new(std::sync::Mutex::new(Some(self.state)))))));
-    }
-}
-
-impl Employee {
-    pub fn work(&self) {
-        print!("{} is working (ID: {})\n", self.name, self.i_d);
-    }
-}
-
-impl Manager {
-    pub fn manage(&self) {
-        print!("Manager {} is managing team: {}\n", self.name, self.team);
     }
 }
 


### PR DESCRIPTION
Completes support for Go's blank identifier (_).

- Add blank identifier to the list of identifiers that shouldn't be unwrapped
- Blank identifier now works in assignments, range loops, and function returns
- Multiple assignment with blank identifier still has issues (related to multiple returns)

The blank identifier test still doesn't fully pass due to multiple assignment issues, but basic blank identifier support is now complete.

Based on #3