### PR TITLE
feat: Add placeholder support for defer statements

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,7 @@
 3. **Test-driven development** - XFAIL tests auto-promote when passing
 4. **Always run tests** before committing or moving to next task
 5. **Update README** when adding support for new Go syntax features
+6. **Include transpiled test outputs** in commits when transpiler changes affect them
 
 ## Core Philosophy: Conservative Translation
 

--- a/go/stmt.go
+++ b/go/stmt.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"go/ast"
 	"go/token"
 	"strings"
@@ -693,5 +694,14 @@ func TranspileStatement(out *strings.Builder, stmt ast.Stmt, fnType *ast.FuncTyp
 		}
 
 		out.WriteString("    }")
+
+	case *ast.DeferStmt:
+		// For now, just add a comment - proper defer support is complex
+		out.WriteString("// defer ")
+		TranspileCall(out, s.Call)
+		out.WriteString(" // TODO: defer not yet supported")
+
+	default:
+		out.WriteString("// TODO: Unhandled statement type: " + strings.TrimPrefix(fmt.Sprintf("%T", s), "*ast."))
 	}
 }

--- a/tests/XFAIL/advanced_control_flow/main.rs
+++ b/tests/XFAIL/advanced_control_flow/main.rs
@@ -1,8 +1,8 @@
 fn main() {
     println!("{}", "=== Nested loops with labels ===".to_string());
-    
+    // TODO: Unhandled statement type: LabeledStmt
     println!("{}", "\n=== Continue with labels ===".to_string());
-    
+    // TODO: Unhandled statement type: LabeledStmt
     println!("{}", "\n=== Complex switch with fallthrough ===".to_string());
     let mut num = std::sync::Arc::new(std::sync::Mutex::new(Some(1)));
     while (*num.lock().unwrap().as_ref().unwrap()) <= 5 {
@@ -10,7 +10,7 @@ fn main() {
         match (*num.lock().unwrap().as_ref().unwrap()) {
         1 => {
             (*fmt.lock().unwrap().as_ref().unwrap()).print(std::sync::Arc::new(std::sync::Mutex::new(Some("One".to_string()))));
-            
+            // TODO: Unhandled statement type: BranchStmt
         }
         2 => {
             (*fmt.lock().unwrap().as_ref().unwrap()).print(std::sync::Arc::new(std::sync::Mutex::new(Some(" Two-ish".to_string()))));
@@ -65,7 +65,7 @@ fn main() {
     while (*i.lock().unwrap().as_ref().unwrap()) < (*j.lock().unwrap().as_ref().unwrap()) {
         print!("i={}, j={}, sum={}\n", (*i.lock().unwrap().as_ref().unwrap()), (*j.lock().unwrap().as_ref().unwrap()), (*i.lock().unwrap().as_ref().unwrap()) + (*j.lock().unwrap().as_ref().unwrap()));
         if (*i.lock().unwrap().as_ref().unwrap()) >= 3 {
-        
+        // TODO: Unhandled statement type: BranchStmt
     }
         { *(*i.lock().unwrap().as_ref().unwrap()).lock().unwrap() = Some((*i.lock().unwrap().as_ref().unwrap()) + 1); *(*j.lock().unwrap().as_ref().unwrap()).lock().unwrap() = Some((*j.lock().unwrap().as_ref().unwrap()) - 1) };
     }
@@ -82,10 +82,10 @@ fn main() {
     }
     println!("{}", "\n=== Goto statements ===".to_string());
     let mut counter = std::sync::Arc::new(std::sync::Mutex::new(Some(0)));
-    
+    // TODO: Unhandled statement type: LabeledStmt
     print!("Counter: {}\n", (*counter.lock().unwrap().as_ref().unwrap()));
     if (*counter.lock().unwrap().as_ref().unwrap()) < 3 {
-        
+        // TODO: Unhandled statement type: BranchStmt
     }
     println!("{}", "Done with goto".to_string());
     println!("{}", "\n=== Complex if-else chains ===".to_string());
@@ -127,14 +127,14 @@ fn main() {
         if num % 2 == 0 {
         if num > 6 {
         print!("Stopping at even number {} (index {})\n", num, i);
-        
+        // TODO: Unhandled statement type: BranchStmt
     }
         print!("Skipping even number {} (index {})\n", num, i);
-        
+        // TODO: Unhandled statement type: BranchStmt
     }
         if num == 7 {
         print!("Found lucky number {} at index {}\n", num, i);
-        
+        // TODO: Unhandled statement type: BranchStmt
     }
         print!("Processing odd number {} (index {})\n", num, i);
     }
@@ -144,11 +144,11 @@ fn main() {
         for (colIdx, cell) in row.iter().enumerate() {
         if cell == "e".to_string() {
         print!("Found center at [{}][{}]: {}\n", rowIdx, colIdx, cell);
-        
+        // TODO: Unhandled statement type: BranchStmt
     }
         if rowIdx == 2 && colIdx == 2 {
         print!("Last cell [{}][{}]: {}\n", rowIdx, colIdx, cell);
-        
+        // TODO: Unhandled statement type: BranchStmt
     }
         print!("[{}][{}]: {} ", rowIdx, colIdx, cell);
     }
@@ -158,11 +158,11 @@ fn main() {
     let mut ch1 = vec![0; 2];
     let mut ch2 = vec![0; 2];
     let mut done = ;
-    
-    
-    
-    
-    
+    // TODO: Unhandled statement type: SendStmt
+    // TODO: Unhandled statement type: SendStmt
+    // TODO: Unhandled statement type: SendStmt
+    // TODO: Unhandled statement type: SendStmt
+    // TODO: Unhandled statement type: GoStmt
     <-(*done.lock().unwrap().as_ref().unwrap());
     println!("{}", "Channel processing complete".to_string());
     println!("{}", "\n=== Complex error handling flow ===".to_string());
@@ -173,7 +173,7 @@ fn main() {
         let mut err = process_data(std::sync::Arc::new(std::sync::Mutex::new(Some(data))));
     if (*err.lock().unwrap().as_ref().unwrap()).is_some() {
         print!("  Error: {}\n", (*err.lock().unwrap().as_ref().unwrap()));
-        
+        // TODO: Unhandled statement type: BranchStmt
     }
         print!("  Success: data is valid\n");
     }

--- a/tests/XFAIL/blank_identifier/main.rs
+++ b/tests/XFAIL/blank_identifier/main.rs
@@ -75,9 +75,9 @@ fn main() {
     }
     println!("{}", "\n=== Blank identifier with channels ===".to_string());
     let mut ch = vec![0; 3];
-    
-    
-    
+    // TODO: Unhandled statement type: SendStmt
+    // TODO: Unhandled statement type: SendStmt
+    // TODO: Unhandled statement type: SendStmt
     close(std::sync::Arc::new(std::sync::Mutex::new(Some((*ch.lock().unwrap().as_ref().unwrap())))));
     for  {
         println!("{}", "Received a value (but ignored it)".to_string());

--- a/tests/XFAIL/channels_basic/main.rs
+++ b/tests/XFAIL/channels_basic/main.rs
@@ -2,7 +2,7 @@ pub fn sender(ch: std::sync::Arc<std::sync::Mutex<Option<Unknown>>>) {
     let mut i = std::sync::Arc::new(std::sync::Mutex::new(Some(1)));
     while (*i.lock().unwrap().as_ref().unwrap()) <= 5 {
         print!("Sending: {}\n", (*i.lock().unwrap().as_ref().unwrap()));
-        
+        // TODO: Unhandled statement type: SendStmt
         (*time.lock().unwrap().as_ref().unwrap()).sleep(std::sync::Arc::new(std::sync::Mutex::new(Some(100 * (*time.lock().unwrap().as_ref().unwrap()).millisecond))));
         { let mut guard = i.lock().unwrap(); *guard = Some(guard.as_ref().unwrap() + 1); }
     }
@@ -14,7 +14,7 @@ pub fn receiver(ch: std::sync::Arc<std::sync::Mutex<Option<Unknown>>>) {
         let (mut value, mut ok) = <-(*ch.lock().unwrap().as_ref().unwrap());
         if !(*ok.lock().unwrap().as_ref().unwrap()) {
         println!("{}", "Channel closed".to_string());
-        
+        // TODO: Unhandled statement type: BranchStmt
     }
         print!("Received: {}\n", (*value.lock().unwrap().as_ref().unwrap()));
     }
@@ -22,13 +22,13 @@ pub fn receiver(ch: std::sync::Arc<std::sync::Mutex<Option<Unknown>>>) {
 
 fn main() {
     let mut ch = ;
-    
-    
+    // TODO: Unhandled statement type: GoStmt
+    // TODO: Unhandled statement type: GoStmt
     (*time.lock().unwrap().as_ref().unwrap()).sleep(std::sync::Arc::new(std::sync::Mutex::new(Some(1 * (*time.lock().unwrap().as_ref().unwrap()).second))));
     let mut buffered = vec![0; 3];
-    
-    
-    
+    // TODO: Unhandled statement type: SendStmt
+    // TODO: Unhandled statement type: SendStmt
+    // TODO: Unhandled statement type: SendStmt
     println!("{}", "Buffered channel contents:".to_string());
     let mut i = std::sync::Arc::new(std::sync::Mutex::new(Some(0)));
     while (*i.lock().unwrap().as_ref().unwrap()) < 3 {
@@ -37,7 +37,7 @@ fn main() {
         { let mut guard = i.lock().unwrap(); *guard = Some(guard.as_ref().unwrap() + 1); }
     }
     let mut numbers = vec![0; 5];
-    
+    // TODO: Unhandled statement type: GoStmt
     println!("{}", "Range over channel:".to_string());
     for num in 0..(*numbers.lock().unwrap().as_ref().unwrap()).len() {
         println!("{} {}", "Number:".to_string(), num);

--- a/tests/XFAIL/complex_expressions/main.rs
+++ b/tests/XFAIL/complex_expressions/main.rs
@@ -49,9 +49,9 @@ fn main() {
     }
     println!("{}", "\n=== Channel expressions ===".to_string());
     let mut ch = vec![0; 3];
-    
-    
-    
+    // TODO: Unhandled statement type: SendStmt
+    // TODO: Unhandled statement type: SendStmt
+    // TODO: Unhandled statement type: SendStmt
     let mut chanResult = std::sync::Arc::new(std::sync::Mutex::new(Some(<-(*ch.lock().unwrap().as_ref().unwrap()) + <-(*ch.lock().unwrap().as_ref().unwrap()) * 2 - <-(*ch.lock().unwrap().as_ref().unwrap()) / 2)));
     print!("Channel expression result: {}\n", (*chanResult.lock().unwrap().as_ref().unwrap()));
     println!("{}", "\n=== Nested function calls ===".to_string());

--- a/tests/XFAIL/concurrency_patterns/main.rs
+++ b/tests/XFAIL/concurrency_patterns/main.rs
@@ -7,25 +7,25 @@ fn main() {
     let mut w = std::sync::Arc::new(std::sync::Mutex::new(Some(1)));
     while (*w.lock().unwrap().as_ref().unwrap()) <= (*numWorkers.lock().unwrap().as_ref().unwrap()) {
         (*wg.lock().unwrap().as_ref().unwrap()).add(std::sync::Arc::new(std::sync::Mutex::new(Some(1))));
-        
+        // TODO: Unhandled statement type: GoStmt
         { let mut guard = w.lock().unwrap(); *guard = Some(guard.as_ref().unwrap() + 1); }
     }
     let mut numJobs = std::sync::Arc::new(std::sync::Mutex::new(Some(9)));
     let mut j = std::sync::Arc::new(std::sync::Mutex::new(Some(1)));
     while (*j.lock().unwrap().as_ref().unwrap()) <= (*numJobs.lock().unwrap().as_ref().unwrap()) {
-        
+        // TODO: Unhandled statement type: SendStmt
         { let mut guard = j.lock().unwrap(); *guard = Some(guard.as_ref().unwrap() + 1); }
     }
     close(std::sync::Arc::new(std::sync::Mutex::new(Some((*jobs.lock().unwrap().as_ref().unwrap())))));
-    
+    // TODO: Unhandled statement type: GoStmt
     for result in 0..(*results.lock().unwrap().as_ref().unwrap()).len() {
         print!("Result: {}\n", result);
     }
     println!("{}", "\n=== Producer-Consumer Pattern ===".to_string());
     let mut buffer = vec![0; 5];
     let mut done = ;
-    
-    
+    // TODO: Unhandled statement type: GoStmt
+    // TODO: Unhandled statement type: GoStmt
     <-(*done.lock().unwrap().as_ref().unwrap());
     println!("{}", "\n=== Fan-out/Fan-in Pattern ===".to_string());
     let mut input = ;
@@ -33,17 +33,17 @@ fn main() {
     let mut c2 = fan_out(std::sync::Arc::new(std::sync::Mutex::new(Some((*input.lock().unwrap().as_ref().unwrap())))));
     let mut c3 = fan_out(std::sync::Arc::new(std::sync::Mutex::new(Some((*input.lock().unwrap().as_ref().unwrap())))));
     let mut output = fan_in(std::sync::Arc::new(std::sync::Mutex::new(Some((*c1.lock().unwrap().as_ref().unwrap())))), std::sync::Arc::new(std::sync::Mutex::new(Some((*c2.lock().unwrap().as_ref().unwrap())))), std::sync::Arc::new(std::sync::Mutex::new(Some((*c3.lock().unwrap().as_ref().unwrap())))));
-    
+    // TODO: Unhandled statement type: GoStmt
     for result in 0..(*output.lock().unwrap().as_ref().unwrap()).len() {
         print!("Fan-in result: {}\n", result);
     }
     println!("{}", "\n=== Pipeline Pattern ===".to_string());
     let mut numbers = ;
-    
+    // TODO: Unhandled statement type: GoStmt
     let mut squares = ;
-    
+    // TODO: Unhandled statement type: GoStmt
     let mut final = ;
-    
+    // TODO: Unhandled statement type: GoStmt
     for result in 0..(*final.lock().unwrap().as_ref().unwrap()).len() {
         print!("Pipeline result: {}\n", result);
     }
@@ -55,7 +55,7 @@ fn main() {
     let mut i = std::sync::Arc::new(std::sync::Mutex::new(Some(1)));
     while (*i.lock().unwrap().as_ref().unwrap()) <= 3 {
         (*wg2.lock().unwrap().as_ref().unwrap()).add(std::sync::Arc::new(std::sync::Mutex::new(Some(1))));
-        
+        // TODO: Unhandled statement type: GoStmt
         { let mut guard = i.lock().unwrap(); *guard = Some(guard.as_ref().unwrap() + 1); }
     }
     (*wg2.lock().unwrap().as_ref().unwrap()).wait();
@@ -67,20 +67,20 @@ fn main() {
     let mut i = std::sync::Arc::new(std::sync::Mutex::new(Some(1)));
     while (*i.lock().unwrap().as_ref().unwrap()) <= 3 {
         (*wg3.lock().unwrap().as_ref().unwrap()).add(std::sync::Arc::new(std::sync::Mutex::new(Some(1))));
-        
+        // TODO: Unhandled statement type: GoStmt
         { let mut guard = i.lock().unwrap(); *guard = Some(guard.as_ref().unwrap() + 1); }
     }
     (*wg3.lock().unwrap().as_ref().unwrap()).wait();
     println!("{}", "\n=== Timeout Pattern ===".to_string());
     let mut slowOperation = std::sync::Arc::new(std::sync::Mutex::new(Some()));
-    
-    
+    // TODO: Unhandled statement type: SelectStmt
+    // TODO: Unhandled statement type: SelectStmt
 }
 
 pub fn fan_out(input: std::sync::Arc<std::sync::Mutex<Option<Unknown>>>) -> std::sync::Arc<std::sync::Mutex<Option<Unknown>>> {
 
     let mut output = ;
-    
+    // TODO: Unhandled statement type: GoStmt
     return std::sync::Arc::new(std::sync::Mutex::new(Some((*output.lock().unwrap().as_ref().unwrap()).clone())));
 }
 
@@ -90,8 +90,8 @@ pub fn fan_in(inputs: std::sync::Arc<std::sync::Mutex<Option<Unknown>>>) -> std:
     let mut wg;
     for (_, input) in (*inputs.lock().unwrap().as_ref().unwrap()).iter().enumerate() {
         (*wg.lock().unwrap().as_ref().unwrap()).add(std::sync::Arc::new(std::sync::Mutex::new(Some(1))));
-        
+        // TODO: Unhandled statement type: GoStmt
     }
-    
+    // TODO: Unhandled statement type: GoStmt
     return std::sync::Arc::new(std::sync::Mutex::new(Some((*output.lock().unwrap().as_ref().unwrap()).clone())));
 }

--- a/tests/XFAIL/defer_statements/main.rs
+++ b/tests/XFAIL/defer_statements/main.rs
@@ -1,16 +1,16 @@
 pub fn defer_example() {
     println!("{}", "Start of function".to_string());
-    
-    
-    
+    // defer println!("{}", "Deferred 1".to_string()) // TODO: defer not yet supported
+    // defer println!("{}", "Deferred 2".to_string()) // TODO: defer not yet supported
+    // defer println!("{}", "Deferred 3".to_string()) // TODO: defer not yet supported
     println!("{}", "Middle of function".to_string());
-    
+    // defer () // TODO: defer not yet supported
     println!("{}", "End of function".to_string());
 }
 
 pub fn defer_with_variables() {
     let mut x = std::sync::Arc::new(std::sync::Mutex::new(Some(10)));
-    
+    // defer () // TODO: defer not yet supported
     { let new_val = 20; *x.lock().unwrap() = Some(new_val); };
     println!("{} {}", "Current x:".to_string(), (*x.lock().unwrap().as_ref().unwrap()));
 }
@@ -19,7 +19,7 @@ pub fn defer_in_loop() {
     println!("{}", "Defer in loop:".to_string());
     let mut i = std::sync::Arc::new(std::sync::Mutex::new(Some(0)));
     while (*i.lock().unwrap().as_ref().unwrap()) < 3 {
-        
+        // defer (std::sync::Arc::new(std::sync::Mutex::new(Some((*i.lock().unwrap().as_ref().unwrap()))))) // TODO: defer not yet supported
         { let mut guard = i.lock().unwrap(); *guard = Some(guard.as_ref().unwrap() + 1); }
     }
     println!("{}", "Loop finished".to_string());
@@ -31,7 +31,7 @@ pub fn cleanup() {
 
 pub fn resource_example() {
     println!("{}", "Acquiring resource".to_string());
-    
+    // defer cleanup() // TODO: defer not yet supported
     println!("{}", "Using resource".to_string());
     let mut i = std::sync::Arc::new(std::sync::Mutex::new(Some(0)));
     while (*i.lock().unwrap().as_ref().unwrap()) < 3 {

--- a/tests/XFAIL/embedded_structs/main.rs
+++ b/tests/XFAIL/embedded_structs/main.rs
@@ -37,18 +37,6 @@ struct Company {
     std::sync::_arc<std::sync::_mutex<_option<_company_info>>>: std::sync::Arc<std::sync::Mutex<Option<CompanyInfo>>>,
 }
 
-impl Employee {
-    pub fn work(&self) {
-        print!("{} is working (ID: {})\n", self.name, self.i_d);
-    }
-}
-
-impl Manager {
-    pub fn manage(&self) {
-        print!("Manager {} is managing team: {}\n", self.name, self.team);
-    }
-}
-
 impl Person {
     pub fn greet(&self) {
         print!("Hello, I'm {}\n", self.name);
@@ -62,6 +50,18 @@ impl Person {
 impl Address {
     pub fn full_address(&self) -> std::sync::Arc<std::sync::Mutex<Option<String>>> {
         return std::sync::Arc::new(std::sync::Mutex::new(Some((*fmt.lock().unwrap().as_ref().unwrap()).sprintf(std::sync::Arc::new(std::sync::Mutex::new(Some("%s, %s, %s".to_string()))), std::sync::Arc::new(std::sync::Mutex::new(Some(self.street))), std::sync::Arc::new(std::sync::Mutex::new(Some(self.city))), std::sync::Arc::new(std::sync::Mutex::new(Some(self.state)))))));
+    }
+}
+
+impl Employee {
+    pub fn work(&self) {
+        print!("{} is working (ID: {})\n", self.name, self.i_d);
+    }
+}
+
+impl Manager {
+    pub fn manage(&self) {
+        print!("Manager {} is managing team: {}\n", self.name, self.team);
     }
 }
 

--- a/tests/XFAIL/file_operations/main.rs
+++ b/tests/XFAIL/file_operations/main.rs
@@ -32,7 +32,7 @@ fn main() {
         print!("Error opening file: {}\n", (*err.lock().unwrap().as_ref().unwrap()));
         return;
     }
-    
+    // defer (*file.lock().unwrap().as_ref().unwrap()).close() // TODO: defer not yet supported
     let mut scanner = (*bufio.lock().unwrap().as_ref().unwrap()).new_scanner(std::sync::Arc::new(std::sync::Mutex::new(Some((*file.lock().unwrap().as_ref().unwrap())))));
     let mut lineNum = std::sync::Arc::new(std::sync::Mutex::new(Some(1)));
     while (*scanner.lock().unwrap().as_ref().unwrap()).scan() {
@@ -87,13 +87,13 @@ fn main() {
         print!("Error opening source file: {}\n", (*err.lock().unwrap().as_ref().unwrap()));
         return;
     }
-    
+    // defer (*sourceFile.lock().unwrap().as_ref().unwrap()).close() // TODO: defer not yet supported
     let (mut destFile, mut err) = (*os.lock().unwrap().as_ref().unwrap()).create(std::sync::Arc::new(std::sync::Mutex::new(Some((*copyFilename.lock().unwrap().as_ref().unwrap())))));
     if (*err.lock().unwrap().as_ref().unwrap()).is_some() {
         print!("Error creating destination file: {}\n", (*err.lock().unwrap().as_ref().unwrap()));
         return;
     }
-    
+    // defer (*destFile.lock().unwrap().as_ref().unwrap()).close() // TODO: defer not yet supported
     let (mut bytesWritten, mut err) = (*io.lock().unwrap().as_ref().unwrap()).copy(std::sync::Arc::new(std::sync::Mutex::new(Some((*destFile.lock().unwrap().as_ref().unwrap())))), std::sync::Arc::new(std::sync::Mutex::new(Some((*sourceFile.lock().unwrap().as_ref().unwrap())))));
     if (*err.lock().unwrap().as_ref().unwrap()).is_some() {
         print!("Error copying file: {}\n", (*err.lock().unwrap().as_ref().unwrap()));
@@ -106,7 +106,7 @@ fn main() {
         print!("Error opening file: {}\n", (*err.lock().unwrap().as_ref().unwrap()));
         return;
     }
-    
+    // defer (*file.lock().unwrap().as_ref().unwrap()).close() // TODO: defer not yet supported
     { let new_val = (*bufio.lock().unwrap().as_ref().unwrap()).new_scanner(std::sync::Arc::new(std::sync::Mutex::new(Some((*file.lock().unwrap().as_ref().unwrap()))))); *scanner.lock().unwrap() = Some(new_val); };
     let mut wordCount = std::sync::Arc::new(std::sync::Mutex::new(Some(0)));
     let mut lineCount = std::sync::Arc::new(std::sync::Mutex::new(Some(0)));
@@ -132,7 +132,7 @@ fn main() {
         print!("Error creating data file: {}\n", (*err.lock().unwrap().as_ref().unwrap()));
         return;
     }
-    
+    // defer (*file.lock().unwrap().as_ref().unwrap()).close() // TODO: defer not yet supported
     (*fmt.lock().unwrap().as_ref().unwrap()).fprintf(std::sync::Arc::new(std::sync::Mutex::new(Some((*file.lock().unwrap().as_ref().unwrap())))), std::sync::Arc::new(std::sync::Mutex::new(Some("Name: %s\n".to_string()))), std::sync::Arc::new(std::sync::Mutex::new(Some("John Doe".to_string()))));
     (*fmt.lock().unwrap().as_ref().unwrap()).fprintf(std::sync::Arc::new(std::sync::Mutex::new(Some((*file.lock().unwrap().as_ref().unwrap())))), std::sync::Arc::new(std::sync::Mutex::new(Some("Age: %d\n".to_string()))), std::sync::Arc::new(std::sync::Mutex::new(Some(30))));
     (*fmt.lock().unwrap().as_ref().unwrap()).fprintf(std::sync::Arc::new(std::sync::Mutex::new(Some((*file.lock().unwrap().as_ref().unwrap())))), std::sync::Arc::new(std::sync::Mutex::new(Some("Score: %.2f\n".to_string()))), std::sync::Arc::new(std::sync::Mutex::new(Some(95.5))));

--- a/tests/XFAIL/goroutines_basic/main.rs
+++ b/tests/XFAIL/goroutines_basic/main.rs
@@ -18,10 +18,10 @@ pub fn counter(start: std::sync::Arc<std::sync::Mutex<Option<i32>>>) {
 
 fn main() {
     println!("{}", "Starting goroutines...".to_string());
-    
-    
-    
-    
+    // TODO: Unhandled statement type: GoStmt
+    // TODO: Unhandled statement type: GoStmt
+    // TODO: Unhandled statement type: GoStmt
+    // TODO: Unhandled statement type: GoStmt
     (*time.lock().unwrap().as_ref().unwrap()).sleep(std::sync::Arc::new(std::sync::Mutex::new(Some(1 * (*time.lock().unwrap().as_ref().unwrap()).second))));
     println!("{}", "Main function ending".to_string());
 }

--- a/tests/XFAIL/init_functions/main.rs
+++ b/tests/XFAIL/init_functions/main.rs
@@ -47,7 +47,7 @@ pub fn init() {
 
 pub fn init() {
     println!("{}", "Sixth init function - with potential panic handling".to_string());
-    
+    // defer () // TODO: defer not yet supported
     if false {
         panic(std::sync::Arc::new(std::sync::Mutex::new(Some("Init function panic!".to_string()))));
     }

--- a/tests/XFAIL/panic_recover/main.rs
+++ b/tests/XFAIL/panic_recover/main.rs
@@ -2,7 +2,7 @@ pub fn safe_divide(a: std::sync::Arc<std::sync::Mutex<Option<f64>>>, b: std::syn
     let mut result: std::sync::Arc<std::sync::Mutex<Option<f64>>> = std::sync::Arc::new(std::sync::Mutex::new(Some(0.0)));
     let mut err: std::sync::Arc<std::sync::Mutex<Option<Box<dyn std::error::Error + Send + Sync>>>> = std::sync::Arc::new(std::sync::Mutex::new(None));
 
-    
+    // defer () // TODO: defer not yet supported
     if (*b.lock().unwrap().as_ref().unwrap()) == 0 {
         panic(std::sync::Arc::new(std::sync::Mutex::new(Some("division by zero".to_string()))));
     }
@@ -14,28 +14,28 @@ pub fn process_slice(slice: std::sync::Arc<std::sync::Mutex<Option<Vec<i32>>>>, 
     let mut value: std::sync::Arc<std::sync::Mutex<Option<i32>>> = std::sync::Arc::new(std::sync::Mutex::new(Some(0)));
     let mut err: std::sync::Arc<std::sync::Mutex<Option<Box<dyn std::error::Error + Send + Sync>>>> = std::sync::Arc::new(std::sync::Mutex::new(None));
 
-    
+    // defer () // TODO: defer not yet supported
     { let new_val = (*slice.lock().unwrap().as_ref().unwrap())[(*index.lock().unwrap().as_ref().unwrap())]; *value.lock().unwrap() = Some(new_val); };
     return (std::sync::Arc::new(std::sync::Mutex::new(Some((*value.lock().unwrap().as_ref().unwrap()).clone()))), std::sync::Arc::new(std::sync::Mutex::new(None)));
 }
 
 pub fn nested_panic() {
-    
+    // defer () // TODO: defer not yet supported
     ();
 }
 
 pub fn demonstrate_panic_types() {
-    
-    
-    
-    
+    // defer () // TODO: defer not yet supported
+    // defer () // TODO: defer not yet supported
+    // defer () // TODO: defer not yet supported
+    // defer () // TODO: defer not yet supported
 }
 
 pub fn chained_defers() {
-    
-    
-    
-    
+    // defer () // TODO: defer not yet supported
+    // defer () // TODO: defer not yet supported
+    // defer () // TODO: defer not yet supported
+    // defer () // TODO: defer not yet supported
     println!("{}", "About to return normally".to_string());
 }
 

--- a/tests/XFAIL/range_loops/main.rs
+++ b/tests/XFAIL/range_loops/main.rs
@@ -38,7 +38,7 @@ fn main() {
     let mut ch = vec![0; 5];
     let mut i = std::sync::Arc::new(std::sync::Mutex::new(Some(1)));
     while (*i.lock().unwrap().as_ref().unwrap()) <= 5 {
-        
+        // TODO: Unhandled statement type: SendStmt
         { let mut guard = i.lock().unwrap(); *guard = Some(guard.as_ref().unwrap() + 1); }
     }
     close(std::sync::Arc::new(std::sync::Mutex::new(Some((*ch.lock().unwrap().as_ref().unwrap())))));
@@ -50,7 +50,7 @@ fn main() {
     println!("{}", "Even numbers only (with continue):".to_string());
     for (_, num) in (*data.lock().unwrap().as_ref().unwrap()).iter().enumerate() {
         if num % 2 != 0 {
-        
+        // TODO: Unhandled statement type: BranchStmt
     }
         print!("{} ", num);
     }
@@ -58,7 +58,7 @@ fn main() {
     println!("{}", "Numbers until 6 (with break):".to_string());
     for (_, num) in (*data.lock().unwrap().as_ref().unwrap()).iter().enumerate() {
         if num > 6 {
-        
+        // TODO: Unhandled statement type: BranchStmt
     }
         print!("{} ", num);
     }

--- a/tests/XFAIL/select_statements/main.rs
+++ b/tests/XFAIL/select_statements/main.rs
@@ -1,43 +1,43 @@
 pub fn basic_select() {
     let mut ch1 = ;
     let mut ch2 = ;
-    
-    
-    
+    // TODO: Unhandled statement type: GoStmt
+    // TODO: Unhandled statement type: GoStmt
+    // TODO: Unhandled statement type: SelectStmt
 }
 
 pub fn select_with_timeout() {
     let mut ch = ;
-    
-    
+    // TODO: Unhandled statement type: GoStmt
+    // TODO: Unhandled statement type: SelectStmt
 }
 
 pub fn select_with_default() {
     let mut ch = vec![0; 1];
-    
-    
-    
+    // TODO: Unhandled statement type: SelectStmt
+    // TODO: Unhandled statement type: SelectStmt
+    // TODO: Unhandled statement type: SelectStmt
 }
 
 pub fn select_loop() {
     let mut ch1 = ;
     let mut ch2 = ;
     let mut quit = ;
-    
-    
-    
+    // TODO: Unhandled statement type: GoStmt
+    // TODO: Unhandled statement type: GoStmt
+    // TODO: Unhandled statement type: GoStmt
     println!("{}", "Starting select loop:".to_string());
     while true {
-        
+        // TODO: Unhandled statement type: SelectStmt
     }
 }
 
 pub fn select_with_send() {
     let mut ch1 = vec![0; 1];
     let mut ch2 = vec![0; 1];
-    
+    // TODO: Unhandled statement type: SelectStmt
     println!("{} {}", "Reading from ch1:".to_string(), <-(*ch1.lock().unwrap().as_ref().unwrap()));
-    
+    // TODO: Unhandled statement type: SelectStmt
 }
 
 fn main() {

--- a/tests/XFAIL/switch_statements/main.rs
+++ b/tests/XFAIL/switch_statements/main.rs
@@ -64,11 +64,11 @@ pub fn switch_with_fallthrough(num: std::sync::Arc<std::sync::Mutex<Option<i32>>
     match (*num.lock().unwrap().as_ref().unwrap()) {
         1 => {
             println!("{}", "One".to_string());
-            
+            // TODO: Unhandled statement type: BranchStmt
         }
         2 => {
             println!("{}", "Two or after One".to_string());
-            
+            // TODO: Unhandled statement type: BranchStmt
         }
         3 => {
             println!("{}", "Three or after Two or after One".to_string());
@@ -80,7 +80,7 @@ pub fn switch_with_fallthrough(num: std::sync::Arc<std::sync::Mutex<Option<i32>>
 }
 
 pub fn type_switch(value: std::sync::Arc<std::sync::Mutex<Option<Box<dyn std::any::Any>>>>) {
-    
+    // TODO: Unhandled statement type: TypeSwitchStmt
 }
 
 fn main() {

--- a/tests/XFAIL/type_assertions/main.rs
+++ b/tests/XFAIL/type_assertions/main.rs
@@ -11,15 +11,15 @@ struct Circle {
     radius: std::sync::Arc<std::sync::Mutex<Option<f64>>>,
 }
 
-impl Rectangle {
-    pub fn area(&self) -> std::sync::Arc<std::sync::Mutex<Option<f64>>> {
-        return std::sync::Arc::new(std::sync::Mutex::new(Some(self.width * self.height)));
-    }
-}
-
 impl Circle {
     pub fn area(&self) -> std::sync::Arc<std::sync::Mutex<Option<f64>>> {
         return std::sync::Arc::new(std::sync::Mutex::new(Some(3.14159 * self.radius * self.radius)));
+    }
+}
+
+impl Rectangle {
+    pub fn area(&self) -> std::sync::Arc<std::sync::Mutex<Option<f64>>> {
+        return std::sync::Arc::new(std::sync::Mutex::new(Some(self.width * self.height)));
     }
 }
 
@@ -43,7 +43,7 @@ pub fn process_value(value: std::sync::Arc<std::sync::Mutex<Option<Box<dyn std::
 }
 
 pub fn assert_without_check(value: std::sync::Arc<std::sync::Mutex<Option<Box<dyn std::any::Any>>>>) {
-    
+    // defer () // TODO: defer not yet supported
     let mut str = std::sync::Arc::new(std::sync::Mutex::new(Some(match (*value.lock().unwrap().as_ref().unwrap()).downcast_ref::<String>() { Some(v) => (v.clone(), true), None => (String::new(), false) })));
     print!("Asserted string: {}\n", (*str.lock().unwrap().as_ref().unwrap()));
 }
@@ -75,6 +75,6 @@ fn main() {
     }
     println!("{}", "\n=== Type switch alternative ===".to_string());
     for (_, val) in (*values.lock().unwrap().as_ref().unwrap()).iter().enumerate() {
-        
+        // TODO: Unhandled statement type: TypeSwitchStmt
     }
 }


### PR DESCRIPTION
Adds basic recognition of defer statements in the transpiler.

- Defer statements are now recognized and transpiled as TODO comments
- Provides a foundation for future proper defer implementation

Proper defer support would require significant architectural changes to handle:
- Collecting deferred calls in a vector
- Executing them in LIFO order at function exit  
- Handling panics and early returns
- Proper variable capture

This PR provides the basic AST handling for defer statements as a starting point.

Based on #4